### PR TITLE
feat:localから送信の際にARC署名を付与しないよう変更

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -65,6 +65,9 @@ DKIM署名およびARCの署名を行うmilterです。
   LogFile:
     Path: /var/log/arcmilter.log
     Mode: 0600
+  MyNetworks:
+  - 127.0.0.0/8
+  - ::1/128
   Domains:
     "example.jp": // DKIM署名するFromのドメイン、ARC署名するRcpt-Toのドメイン
       HeaderCanonicalization: "relaxed" // ヘッダの正規化方法

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ I welcome feedback and pull requests.
   LogFile:
     Path: /var/log/arcmilter.log
     Mode: 0600
+  MyNetworks:
+  - 127.0.0.0/8
+  - ::1/128
   Domains:
     "example.jp": // Domain for DKIM signing in From field, and ARC signing in Rcpt-To field
       HeaderCanonicalization: "relaxed" // Header normalization method

--- a/arcmilter/arcmilter.go
+++ b/arcmilter/arcmilter.go
@@ -103,14 +103,14 @@ func (s *Session) RcptTo(rcptTo string, esmtpArgs string, m *milter.Modifier) (*
 	if s.authn != "" || s.conf.IsMyNetwork(s.remoteAddr) {
 		return milter.RespContinue, nil
 	}
-	domain, err := mmauth.ParseAddressDomain(rcptTo)
+	rpctToDomain, err := mmauth.ParseAddressDomain(rcptTo)
 	if err != nil {
 		log.Printf("util.ParseAddressDomain: %v", err)
 		return milter.RespContinue, nil
 	}
-	s.rcptToDomain = domain
+	s.rcptToDomain = rpctToDomain
 	// 署名の準備
-	if domain, ok := (s.conf.Domains)[domain]; ok {
+	if domain, ok := (s.conf.Domains)[rpctToDomain]; ok {
 		// 宛先が対象ドメインならARC署名を行う
 		s.isARCSign = true
 		s.mmauth.AddBodyHash(mmauth.BodyCanonicalizationAndAlgorithm{

--- a/cmd/arcmilter/arcmilter.yaml.sample
+++ b/cmd/arcmilter/arcmilter.yaml.sample
@@ -28,6 +28,9 @@ Domains:
     PrivateKeyFile: "/etc/arcmilter/keys/example.com.key"
     DKIM: true
     ARC: true
+MyNetworks:
+  - 127.0.0.0/8
+  - ::1/128
 User: mail
 Group: mail
 ARCSignHeaders:

--- a/cmd/arcmilter/t/test.yaml
+++ b/cmd/arcmilter/t/test.yaml
@@ -10,6 +10,9 @@ PIDFile:
 LogFile:
   Path: ./t/tmp/arcmilter.log
   Mode: 0600
+MyNetworks:
+  - 127.0.0.0/8
+  - ::1/128
 Domains:
   "example.jp":
     HeaderCanonicalization: "relaxed"


### PR DESCRIPTION
issue #4 における修正

* localからの送信および、SMTP Auth認証での送信の場合は転送ではないためARC署名を行わないようにした。
  * SPFのチェックに問題が発生するため。