### PR TITLE
MilterListenのOwnerとGroup指定ができるように変更

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -57,6 +57,8 @@ DKIM署名およびARCの署名を行うmilterです。
   #  Network: unix
   #  Address: /var/run/arcmilter.sock
   #  Mode: 0600
+  #  Owner: postfix // デフォルト: 実行ユーザ
+  #  Group: postfix // デフォルト: 実行グループ
   ControlSocketFile:
     Path: /var/run/arcmilterctl.sock
     Mode: 0600

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ I welcome feedback and pull requests.
   #  Network: unix
   #  Address: /var/run/arcmilter.sock
   #  Mode: 0600
+  #  Owner: postfix // Default: Execution user
+  #  Group: postfix // Default: Execution group
   ControlSocketFile:
     Path: /var/run/arcmilterctl.sock
     Mode: 0600

--- a/cmd/arcmilter/arcmilter.yaml.sample
+++ b/cmd/arcmilter/arcmilter.yaml.sample
@@ -5,6 +5,8 @@ MilterListen:
 #  Network: unix
 #  Address: /var/run/arcmilter.sock
 #  Mode: 0600
+#  Owner: postfix
+#  Group: postfix
 ControlSocketFile:
   Path: /var/run/arcmilterctl.sock
   Mode: 0600

--- a/cmd/arcmilter/main.go
+++ b/cmd/arcmilter/main.go
@@ -318,6 +318,10 @@ func main() {
 		if err := os.Chmod(conf.MilterListen.Address, fs.FileMode(conf.MilterListen.Mode)); err != nil {
 			log.Fatalf("Failed to change socket permission: %v", err)
 		}
+		// socketのオーナーを変更
+		if err := os.Chown(conf.MilterListen.Address, conf.MilterListen.Uid, conf.MilterListen.Gid); err != nil {
+			log.Fatalf("Failed to change socket owner: %v", err)
+		}
 		msockfd, err = msocket.(*net.UnixListener).File()
 		if err != nil {
 			log.Fatalf("Failed to get socket fd: %v", err)


### PR DESCRIPTION
https://github.com/masa23/arcmilter/issues/10 User/Group ignored

MilterListenでUnixDomainSocketの場合にOwnerとGroupを変更できるように設定を追加
未設定の場合はarcmilter実行ユーザとなる。

pidファイルについては、arcmilter実行ユーザと異なる必要はないため設定追加は行わない。