### PR TITLE
DKIMのLimitがある場合のBodyHashへの指定漏れを修正

### DIFF
--- a/mmauth/mmauth.go
+++ b/mmauth/mmauth.go
@@ -60,6 +60,7 @@ func (a *AuthenticationHeaders) BodyHashCanonAndAlgo() []BodyCanonicalizationAnd
 		bca := BodyCanonicalizationAndAlgorithm{
 			Body:      body,
 			Algorithm: hashAlgo(SignatureAlgorithm(dkim.Algorithm)),
+			Limit:     dkim.Limit,
 		}
 		if !isCcanonicalizationBodyAndAlgorithm(bca, ret) {
 			ret = append(ret, bca)


### PR DESCRIPTION
* DKIMのl=が指定されている場合の値の受け渡しが漏れていたので修正