### PR TITLE
ParseError周りのエラーハンドリングを修正

### DIFF
--- a/mmauth/header.go
+++ b/mmauth/header.go
@@ -117,7 +117,7 @@ func ParseDKIMHeaders(headers []string) (*DKIMSignatures, error) {
 		case "dkim-signature":
 			sig, err := dkim.ParseSignature(h)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse dkim-signature: %v", err)
+				return &sigs, fmt.Errorf("failed to parse dkim-signature: %v", err)
 			}
 			sigs = append(sigs, sig)
 		}
@@ -220,33 +220,33 @@ func ParseARCHeaders(headers []string) (*ARCSignatures, error) {
 		case "arc-seal":
 			ret, err := arc.ParseARCSeal(h)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse arc-seal: %v", err)
+				return &sigs, fmt.Errorf("failed to parse arc-seal: %v", err)
 			}
 			// インスタンス番号が50以上の場合はエラー
 			if ret.InstanceNumber > 50 {
-				return nil, fmt.Errorf("instance number is too large")
+				return &sigs, fmt.Errorf("instance number is too large")
 			}
 			as := sigs.GetInstance(ret.InstanceNumber)
 			as.ARCSeal = ret
 		case "arc-authentication-results":
 			ret, err := arc.ParseARCAuthenticationResults(h)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse arc-authentication-results: %v", err)
+				return &sigs, fmt.Errorf("failed to parse arc-authentication-results: %v", err)
 			}
 			// インスタンス番号が50以上の場合はエラー
 			if ret.InstanceNumber > 50 {
-				return nil, fmt.Errorf("instance number is too large")
+				return &sigs, fmt.Errorf("instance number is too large")
 			}
 			as := sigs.GetInstance(ret.InstanceNumber)
 			as.ARCAuthenticationResults = ret
 		case "arc-message-signature":
 			ret, err := arc.ParseARCMessageSignature(h)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse arc-message-signature: %v", err)
+				return &sigs, fmt.Errorf("failed to parse arc-message-signature: %v", err)
 			}
 			// インスタンス番号が50以上の場合はエラー
 			if ret.InstanceNumber > 50 {
-				return nil, fmt.Errorf("instance number is too large")
+				return &sigs, fmt.Errorf("instance number is too large")
 			}
 			as := sigs.GetInstance(ret.InstanceNumber)
 			as.ARCMessageSignature = ret
@@ -258,11 +258,11 @@ func ParseARCHeaders(headers []string) (*ARCSignatures, error) {
 		// インスタンスが連続していない場合はエラー
 		ah := sigs.GetInstance(i)
 		if ah == nil {
-			return nil, fmt.Errorf("instance number is not continuous")
+			return &sigs, fmt.Errorf("instance number is not continuous")
 		}
 		// ARC-Seal、ARC-Authentication-Results、ARC-Message-Signatureがない場合はエラー
 		if ah.ARCSeal == nil || ah.ARCAuthenticationResults == nil || ah.ARCMessageSignature == nil {
-			return nil, fmt.Errorf("arc headers are missing")
+			return &sigs, fmt.Errorf("arc headers are missing")
 		}
 	}
 

--- a/mmauth/header.go
+++ b/mmauth/header.go
@@ -117,7 +117,7 @@ func ParseDKIMHeaders(headers []string) (*DKIMSignatures, error) {
 		case "dkim-signature":
 			sig, err := dkim.ParseSignature(h)
 			if err != nil {
-				return &sigs, fmt.Errorf("failed to parse dkim-signature: %v", err)
+				return nil, fmt.Errorf("failed to parse dkim-signature: %v", err)
 			}
 			sigs = append(sigs, sig)
 		}
@@ -129,6 +129,9 @@ type ARCSignatures []*arc.Signature
 
 // インスタンス番号を指定してSignatureを取得する
 func (s *ARCSignatures) GetInstance(i int) *arc.Signature {
+	if s == nil {
+		return nil
+	}
 	for _, sig := range *s {
 		if sig.InstanceNumber == i {
 			return sig
@@ -143,6 +146,9 @@ func (s *ARCSignatures) GetInstance(i int) *arc.Signature {
 
 // 最大のインスタンス番号を取得する
 func (s *ARCSignatures) GetMaxInstance() int {
+	if s == nil {
+		return 0
+	}
 	max := 0
 	for _, sig := range *s {
 		if sig.InstanceNumber > max {
@@ -154,6 +160,9 @@ func (s *ARCSignatures) GetMaxInstance() int {
 
 // 最後のARCのVerify結果を文字列で取得する
 func (s *ARCSignatures) GetVerifyResultString() string {
+	if s == nil {
+		return "arc=none"
+	}
 	max := s.GetMaxInstance()
 	if max == 0 {
 		return "arc=none"
@@ -169,6 +178,9 @@ func (s *ARCSignatures) GetVerifyResultString() string {
 
 // 最後のARCのVerify結果を取得する
 func (s *ARCSignatures) GetVerifyResult() arc.VerifyStatus {
+	if s == nil {
+		return arc.VerifyStatusNone
+	}
 	max := s.GetMaxInstance()
 	if max == 0 {
 		return arc.VerifyStatusNone
@@ -186,6 +198,9 @@ func (s *ARCSignatures) GetVerifyResult() arc.VerifyStatus {
 // i=1がNone以外の場合はFail
 // それ以外のインスタンスがPassでなければFail
 func (s *ARCSignatures) GetARCChainValidation() arc.ChainValidationResult {
+	if s == nil {
+		return arc.ChainValidationResultNone
+	}
 	max := s.GetMaxInstance()
 	// インスタンスがない場合はNone
 	if max == 0 {
@@ -220,33 +235,33 @@ func ParseARCHeaders(headers []string) (*ARCSignatures, error) {
 		case "arc-seal":
 			ret, err := arc.ParseARCSeal(h)
 			if err != nil {
-				return &sigs, fmt.Errorf("failed to parse arc-seal: %v", err)
+				return nil, fmt.Errorf("failed to parse arc-seal: %v", err)
 			}
 			// インスタンス番号が50以上の場合はエラー
 			if ret.InstanceNumber > 50 {
-				return &sigs, fmt.Errorf("instance number is too large")
+				return nil, fmt.Errorf("instance number is too large")
 			}
 			as := sigs.GetInstance(ret.InstanceNumber)
 			as.ARCSeal = ret
 		case "arc-authentication-results":
 			ret, err := arc.ParseARCAuthenticationResults(h)
 			if err != nil {
-				return &sigs, fmt.Errorf("failed to parse arc-authentication-results: %v", err)
+				return nil, fmt.Errorf("failed to parse arc-authentication-results: %v", err)
 			}
 			// インスタンス番号が50以上の場合はエラー
 			if ret.InstanceNumber > 50 {
-				return &sigs, fmt.Errorf("instance number is too large")
+				return nil, fmt.Errorf("instance number is too large")
 			}
 			as := sigs.GetInstance(ret.InstanceNumber)
 			as.ARCAuthenticationResults = ret
 		case "arc-message-signature":
 			ret, err := arc.ParseARCMessageSignature(h)
 			if err != nil {
-				return &sigs, fmt.Errorf("failed to parse arc-message-signature: %v", err)
+				return nil, fmt.Errorf("failed to parse arc-message-signature: %v", err)
 			}
 			// インスタンス番号が50以上の場合はエラー
 			if ret.InstanceNumber > 50 {
-				return &sigs, fmt.Errorf("instance number is too large")
+				return nil, fmt.Errorf("instance number is too large")
 			}
 			as := sigs.GetInstance(ret.InstanceNumber)
 			as.ARCMessageSignature = ret
@@ -258,11 +273,11 @@ func ParseARCHeaders(headers []string) (*ARCSignatures, error) {
 		// インスタンスが連続していない場合はエラー
 		ah := sigs.GetInstance(i)
 		if ah == nil {
-			return &sigs, fmt.Errorf("instance number is not continuous")
+			return nil, fmt.Errorf("instance number is not continuous")
 		}
 		// ARC-Seal、ARC-Authentication-Results、ARC-Message-Signatureがない場合はエラー
 		if ah.ARCSeal == nil || ah.ARCAuthenticationResults == nil || ah.ARCMessageSignature == nil {
-			return &sigs, fmt.Errorf("arc headers are missing")
+			return nil, fmt.Errorf("arc headers are missing")
 		}
 	}
 
@@ -271,6 +286,9 @@ func ParseARCHeaders(headers []string) (*ARCSignatures, error) {
 
 // ARCヘッダをSealで署名する順番にソートする
 func (s *ARCSignatures) GetARCHeaders() []string {
+	if s == nil {
+		return nil
+	}
 	var ret []string
 	max := s.GetMaxInstance()
 	if max <= 0 {

--- a/mmauth/mmauth.go
+++ b/mmauth/mmauth.go
@@ -37,17 +37,18 @@ type AuthenticationHeaders struct {
 }
 
 func parseAuthentications(headers headers) (*AuthenticationHeaders, error) {
-	var err error
-	var ah AuthenticationHeaders
-	ah.DKIMSignatures, err = ParseDKIMHeaders(headers)
+	d, err := ParseDKIMHeaders(headers)
 	if err != nil {
-		return &ah, fmt.Errorf("failed to parse dkim headers: %v", err)
+		return nil, fmt.Errorf("failed to parse dkim headers: %v", err)
 	}
-	ah.ARCSignatures, err = ParseARCHeaders(headers)
+	a, err := ParseARCHeaders(headers)
 	if err != nil {
-		return &ah, fmt.Errorf("failed to parse arc headers: %v", err)
+		return nil, fmt.Errorf("failed to parse arc headers: %v", err)
 	}
-	return &ah, nil
+	return &AuthenticationHeaders{
+		DKIMSignatures: d,
+		ARCSignatures:  a,
+	}, nil
 }
 
 func (a *AuthenticationHeaders) BodyHashCanonAndAlgo() []BodyCanonicalizationAndAlgorithm {

--- a/mmauth/mmauth.go
+++ b/mmauth/mmauth.go
@@ -37,18 +37,17 @@ type AuthenticationHeaders struct {
 }
 
 func parseAuthentications(headers headers) (*AuthenticationHeaders, error) {
-	d, err := ParseDKIMHeaders(headers)
+	var err error
+	var ah AuthenticationHeaders
+	ah.DKIMSignatures, err = ParseDKIMHeaders(headers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse dkim headers: %v", err)
+		return &ah, fmt.Errorf("failed to parse dkim headers: %v", err)
 	}
-	a, err := ParseARCHeaders(headers)
+	ah.ARCSignatures, err = ParseARCHeaders(headers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse arc headers: %v", err)
+		return &ah, fmt.Errorf("failed to parse arc headers: %v", err)
 	}
-	return &AuthenticationHeaders{
-		DKIMSignatures: d,
-		ARCSignatures:  a,
-	}, nil
+	return &ah, nil
 }
 
 func (a *AuthenticationHeaders) BodyHashCanonAndAlgo() []BodyCanonicalizationAndAlgorithm {
@@ -241,6 +240,9 @@ func NewMMAuth() *MMAuth {
 
 // ヘッダ、本文の書き込み
 func (m *MMAuth) Write(p []byte) (n int, err error) {
+	if m.err != nil {
+		return 0, m.err
+	}
 	return m.pw.Write(p)
 }
 


### PR DESCRIPTION
parsedMail() で何らかのエラーが発生すると、Writeがブロックしてしまうため、エラーハンドリングを修正