### PR TITLE
mmauth.NewMMAuth()のタイミングを修正・子プロセス異常終了時に自動起動を追加

### DIFF
--- a/cmd/arcmilter/main.go
+++ b/cmd/arcmilter/main.go
@@ -241,7 +241,10 @@ func execChildProcess(logfd, msockfd *os.File) {
 	if err != nil {
 		log.Printf("child process wait error: %v", err)
 		// 子プロセスが異常終了した場合は再起動
-		go execChildProcess(logfd, msockfd)
+		// すでに子プロセスが2以上起動している場合は再起動しない
+		if len(childlen) < 2 {
+			go execChildProcess(logfd, msockfd)
+		}
 	}
 	// childlenから消す
 	for i, c := range childlen {

--- a/cmd/arcmilter/main.go
+++ b/cmd/arcmilter/main.go
@@ -240,6 +240,8 @@ func execChildProcess(logfd, msockfd *os.File) {
 	err = cmd.Wait()
 	if err != nil {
 		log.Printf("child process wait error: %v", err)
+		// 子プロセスが異常終了した場合は再起動
+		go execChildProcess(logfd, msockfd)
 	}
 	// childlenから消す
 	for i, c := range childlen {


### PR DESCRIPTION
* ConnectでNewMMAuthをしていたが、不具合が発生するためタイミングを変更
* 子プロセス異常終了時に子プロセスを再起動するように変更