### PR TITLE
ARC署名が不完全な場合にnilのパターンで落ちる不具合を修正

### DIFF
--- a/mmauth/mmauth.go
+++ b/mmauth/mmauth.go
@@ -70,6 +70,9 @@ func (a *AuthenticationHeaders) BodyHashCanonAndAlgo() []BodyCanonicalizationAnd
 	}
 
 	for _, arc := range *a.ARCSignatures {
+		if arc.ARCMessageSignature == nil {
+			continue
+		}
 		_, body, err := parseHeaderCanonicalization(arc.ARCMessageSignature.Canonicalization)
 		if err != nil {
 			continue


### PR DESCRIPTION
### **User description**
* ARCMessageSignatureがDKIM署名不十分でnilにで落ちる不具合の修正


___

### **PR Type**
Bug fix


___

### **Description**
- ARC署名がnilの場合の処理を追加

- nilポインタによるクラッシュを防止


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mmauth.go</strong><dd><code>ARC署名のnilチェック追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mmauth/mmauth.go

- ARCMessageSignatureがnilの場合のチェック追加
- nilポインタによるエラーを防止


</details>


  </td>
  <td><a href="https://github.com/masa23/arcmilter/pull/29/files#diff-d92ca78aa3e29e630d5fa694dca49c48032c85ea03974dfdafb7ec9198b526e5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>