### PR TITLE
署名対象ドメインの柔軟性を向上

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -60,8 +60,8 @@ DKIM署名およびARCの署名を行うmilterです。
   #  Network: unix
   #  Address: /var/run/arcmilter.sock
   #  Mode: 0600
-  #  Owner: postfix // デフォルト: 実行ユーザ
-  #  Group: postfix // デフォルト: 実行グループ
+  #  Owner: postfix # デフォルト: 実行ユーザ
+  #  Group: postfix # デフォルト: 実行グループ
   ControlSocketFile:
     Path: /var/run/arcmilterctl.sock
     Mode: 0600
@@ -74,25 +74,25 @@ DKIM署名およびARCの署名を行うmilterです。
   - 127.0.0.0/8
   - ::1/128
   Domains:
-    // ドメイン名は以下のパターンマッチング構文で指定できます：
-    //
-    // 1. 完全一致: "example.jp" - 完全一致するドメインのみ
-    // 2. ワイルドカード: "*.example.jp" - example.jp およびそのサブドメインにマッチ
-    // 3. デフォルト: "*" - どのパターンにもマッチしない場合に使用
-    //
-    // マッチングの優先順位: 完全一致 > ワイルドカード（より具体的なもの） > デフォルト
-    //
-    // 複数のドメイン・パターンをカンマ区切りで一括指定することもできます：
-    // "list:example.com,sub.example.com,*.example.net"
-    //
-    "example.jp": // DKIM署名するFromのドメイン、ARC署名するRcpt-Toのドメイン
-      HeaderCanonicalization: "relaxed" // ヘッダの正規化方法
-      BodyCanonicalization: "relaxed"   // ボディの正規化方法
-      Selector: "default"               // セレクタ
-      PrivateKeyFile: "/etc/arcmilter/keys/example.jp.key" // 秘密鍵のパス
-      DKIM: true  // DKIM署名を行うか
-      ARC: true   // ARC署名を行うか
-    "example.com": // 複数のドメインを設定可能
+    # ドメイン名は以下のパターンマッチング構文で指定できます：
+    #
+    # 1. 完全一致: "example.jp" - 完全一致するドメインのみ
+    # 2. ワイルドカード: "*.example.jp" - example.jp およびそのサブドメインにマッチ
+    # 3. デフォルト: "*" - どのパターンにもマッチしない場合に使用
+    #
+    # マッチングの優先順位: 完全一致 > ワイルドカード（より具体的なもの） > デフォルト
+    #
+    # 複数のドメイン・パターンをカンマ区切りで一括指定することもできます：
+    # "list:example.com,sub.example.com,*.example.net"
+    #
+    "example.jp": # DKIM署名するFromのドメイン、ARC署名するRcpt-Toのドメイン
+      HeaderCanonicalization: "relaxed" # ヘッダの正規化方法
+      BodyCanonicalization: "relaxed"   # ボディの正規化方法
+      Selector: "default"               # セレクタ
+      PrivateKeyFile: "/etc/arcmilter/keys/example.jp.key" # 秘密鍵のパス
+      DKIM: true  # DKIM署名を行うか
+      ARC: true   # ARC署名を行うか
+    "example.com": # 複数のドメインを設定可能
       HeaderBodyCanonicalization: "relaxed"
       BodyCanonicalization: "relaxed"
       Selector: "default"
@@ -100,15 +100,15 @@ DKIM署名およびARCの署名を行うmilterです。
       PrivateKeyFile: "/etc/arcmilter/keys/example.com.key"
       DKIM: true
       ARC: true
-  User: mail  // milterの子プロセス実行ユーザ    デフォルト: 実行ユーザ
-  Group: mail // milterの子プロセス実行グループ  デフォルト: 実行グループ
-  ARCSignHeaders: // ARC署名するヘッダ
+  User: mail  # milterの子プロセス実行ユーザ    デフォルト: 実行ユーザ
+  Group: mail # milterの子プロセス実行グループ  デフォルト: 実行グループ
+  ARCSignHeaders: # ARC署名するヘッダ
     - "DKIM-Signature"
     - "Date"
     - "From"
     - "To"
     - "Message-Id"
-  DKIMSignHeaders: // DKIM署名するヘッダ
+  DKIMSignHeaders: # DKIM署名するヘッダ
     - "Date"
     - "From"
     - "To"

--- a/README.ja.md
+++ b/README.ja.md
@@ -74,6 +74,17 @@ DKIM署名およびARCの署名を行うmilterです。
   - 127.0.0.0/8
   - ::1/128
   Domains:
+    // ドメイン名は以下のパターンマッチング構文で指定できます：
+    //
+    // 1. 完全一致: "example.jp" - 完全一致するドメインのみ
+    // 2. ワイルドカード: "*.example.jp" - example.jp およびそのサブドメインにマッチ
+    // 3. デフォルト: "*" - どのパターンにもマッチしない場合に使用
+    //
+    // マッチングの優先順位: 完全一致 > ワイルドカード（より具体的なもの） > デフォルト
+    //
+    // 複数のドメイン・パターンをカンマ区切りで一括指定することもできます：
+    // "list:example.com,sub.example.com,*.example.net"
+    //
     "example.jp": // DKIM署名するFromのドメイン、ARC署名するRcpt-Toのドメイン
       HeaderCanonicalization: "relaxed" // ヘッダの正規化方法
       BodyCanonicalization: "relaxed"   // ボディの正規化方法

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ I welcome feedback and pull requests.
   #  Network: unix
   #  Address: /var/run/arcmilter.sock
   #  Mode: 0600
-  #  Owner: postfix // Default: Execution user
-  #  Group: postfix // Default: Execution group
+  #  Owner: postfix # Default: Execution user
+  #  Group: postfix # Default: Execution group
   ControlSocketFile:
     Path: /var/run/arcmilterctl.sock
     Mode: 0600
@@ -73,25 +73,25 @@ I welcome feedback and pull requests.
   - 127.0.0.0/8
   - ::1/128
   Domains:
-    // Domain names can be specified using these pattern matching syntax:
-    //
-    // 1. Exact match: "example.jp" - Matches only this exact domain
-    // 2. Wildcard: "*.example.jp" - Matches example.jp and all its subdomains
-    // 3. Default: "*" - Used when no other pattern matches
-    //
-    // Matching priority: Exact match > Wildcard (more specific) > Default
-    //
-    // You can also specify multiple domains/patterns separated by commas:
-    // "list:example.com,sub.example.com,*.example.net"
-    //
-    "example.jp": // Domain for DKIM signing in From field, and ARC signing in Rcpt-To field
-      HeaderCanonicalization: "relaxed" // Header normalization method
-      BodyCanonicalization: "relaxed"   // Body normalization method
-      Selector: "default"               // Selector
-      PrivateKeyFile: "/etc/arcmilter/keys/example.jp.key" // Path to private key
-      DKIM: true  // Enable DKIM signing
-      ARC: true   // Enable ARC signing
-    "example.com": // You can configure multiple domains
+    # Domain names can be specified using these pattern matching syntax:
+    #
+    # 1. Exact match: "example.jp" - Matches only this exact domain
+    # 2. Wildcard: "*.example.jp" - Matches example.jp and all its subdomains
+    # 3. Default: "*" - Used when no other pattern matches
+    #
+    # Matching priority: Exact match > Wildcard (more specific) > Default
+    #
+    # You can also specify multiple domains/patterns separated by commas:
+    # "list:example.com,sub.example.com,*.example.net"
+    #
+    "example.jp": # Domain for DKIM signing in From field, and ARC signing in Rcpt-To field
+      HeaderCanonicalization: "relaxed" # Header normalization method
+      BodyCanonicalization: "relaxed"   # Body normalization method
+      Selector: "default"               # Selector
+      PrivateKeyFile: "/etc/arcmilter/keys/example.jp.key" # Path to private key
+      DKIM: true  # Enable DKIM signing
+      ARC: true   # Enable ARC signing
+    "example.com": # You can configure multiple domains
       HeaderBodyCanonicalization: "relaxed"
       BodyCanonicalization: "relaxed"
       Selector: "default"
@@ -99,15 +99,15 @@ I welcome feedback and pull requests.
       PrivateKeyFile: "/etc/arcmilter/keys/example.com.key"
       DKIM: true
       ARC: true
-  User: mail  // User to run the milter
-  Group: mail // Group to run the milter
-  ARCSignHeaders: // Headers to sign with ARC
+  User: mail  # User to run the milter
+  Group: mail # Group to run the milter
+  ARCSignHeaders: # Headers to sign with ARC
     - "DKIM-Signature"
     - "Date"
     - "From"
     - "To"
     - "Message-Id"
-  DKIMSignHeaders: // Headers to sign with DKIM
+  DKIMSignHeaders: # Headers to sign with DKIM
     - "Date"
     - "From"
     - "To"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ I welcome feedback and pull requests.
   - 127.0.0.0/8
   - ::1/128
   Domains:
+    // Domain names can be specified using these pattern matching syntax:
+    //
+    // 1. Exact match: "example.jp" - Matches only this exact domain
+    // 2. Wildcard: "*.example.jp" - Matches example.jp and all its subdomains
+    // 3. Default: "*" - Used when no other pattern matches
+    //
+    // Matching priority: Exact match > Wildcard (more specific) > Default
+    //
+    // You can also specify multiple domains/patterns separated by commas:
+    // "list:example.com,sub.example.com,*.example.net"
+    //
     "example.jp": // Domain for DKIM signing in From field, and ARC signing in Rcpt-To field
       HeaderCanonicalization: "relaxed" // Header normalization method
       BodyCanonicalization: "relaxed"   // Body normalization method

--- a/arcmilter/arcmilter.go
+++ b/arcmilter/arcmilter.go
@@ -136,7 +136,7 @@ func (s *Session) Header(name, value string, m *milter.Modifier) (*milter.Respon
 		}
 		s.fromDomain = fromDomain
 
-		if domain, ok := (s.conf.Domains)[s.fromDomain]; ok {
+		if domain, ok := s.conf.GetMatchingDomain(s.fromDomain); ok && domain.DKIM {
 			// 送信元が対象ドメインなら正規化とハッシュアルゴリズムを設定
 			s.mmauth.AddBodyHash(mmauth.BodyCanonicalizationAndAlgorithm{
 				Body:      mmauth.Canonicalization(domain.BodyCanonicalization),
@@ -145,6 +145,8 @@ func (s *Session) Header(name, value string, m *milter.Modifier) (*milter.Respon
 			})
 			// DKIM署名を行う
 			s.isDKIMSign = true
+		} else {
+			s.isDKIMSign = false
 		}
 		return milter.RespContinue, nil
 	}

--- a/arcmilter/arcmilter.go
+++ b/arcmilter/arcmilter.go
@@ -110,7 +110,7 @@ func (s *Session) RcptTo(rcptTo string, esmtpArgs string, m *milter.Modifier) (*
 	}
 	s.rcptToDomain = rpctToDomain
 	// 署名の準備
-	if domain, ok := (s.conf.Domains)[rpctToDomain]; ok {
+	if domain, ok := s.conf.GetMatchingDomain(rpctToDomain); ok {
 		// 宛先が対象ドメインならARC署名を行う
 		s.isARCSign = true
 		s.mmauth.AddBodyHash(mmauth.BodyCanonicalizationAndAlgorithm{
@@ -179,7 +179,7 @@ func DKIMSign(s *Session, m *milter.Modifier) {
 	}
 
 	// 対応するドメインのキーがある場合はDKIM署名を行う
-	if domain, ok := (s.conf.Domains)[s.fromDomain]; ok && domain.DKIM {
+	if domain, ok := s.conf.GetMatchingDomain(s.fromDomain); ok && domain.DKIM {
 		bodyHash := s.mmauth.GetBodyHash(mmauth.BodyCanonicalizationAndAlgorithm{
 			Body:      mmauth.Canonicalization(domain.BodyCanonicalization),
 			Algorithm: domain.HashAlgo,
@@ -227,7 +227,7 @@ func ARCSign(s *Session, m *milter.Modifier) {
 		return
 	}
 
-	if domain, ok := (s.conf.Domains)[s.rcptToDomain]; ok && domain.ARC {
+	if domain, ok := s.conf.GetMatchingDomain(s.rcptToDomain); ok && domain.ARC {
 		if s.mmauth.AuthenticationHeaders == nil {
 			log.Printf("AuthenticationHeaders is nil")
 		}

--- a/cmd/arcmilter/arcmilter.yaml.sample
+++ b/cmd/arcmilter/arcmilter.yaml.sample
@@ -16,6 +16,7 @@ LogFile:
   Path: /var/log/arcmilter.log
   Mode: 0600
 Domains:
+  # 通常のドメイン指定（完全一致）
   "example.jp":
     HeaderCanonicalization: "relaxed"
     BodyCanonicalization: "relaxed"
@@ -31,6 +32,34 @@ Domains:
     PrivateKeyFile: "/etc/arcmilter/keys/example.com.key"
     DKIM: true
     ARC: true
+
+  # ワイルドカードパターン：*.example.com は example.com および sub.example.com にマッチ
+  # "example.com" は上記で定義済みなので、完全一致が優先されます
+  "*.example.net":
+    HeaderCanonicalization: "relaxed"
+    BodyCanonicalization: "relaxed"
+    Selector: "default"
+    PrivateKeyFile: "/etc/arcmilter/keys/example.net.key"
+    DKIM: true
+    ARC: true
+
+  # 複数ドメイン一覧表記：カンマ区切りで複数のドメイン・パターンを指定
+  "list:*.customer.com,*.customer.net,*.customer.org":
+    HeaderCanonicalization: "relaxed"
+    BodyCanonicalization: "relaxed"
+    Selector: "customer"
+    PrivateKeyFile: "/etc/arcmilter/keys/customer.key"
+    DKIM: true
+    ARC: true
+
+  # デフォルト設定：どのパターンにもマッチしないドメインはこれを使用
+  "*":
+    HeaderCanonicalization: "relaxed"
+    BodyCanonicalization: "relaxed"
+    Selector: "default"
+    PrivateKeyFile: "/etc/arcmilter/keys/default.key"
+    DKIM: true
+    ARC: false
 MyNetworks:
   - 127.0.0.0/8
   - ::1/128

--- a/cmd/arcmilter/arcmilter.yaml.sample
+++ b/cmd/arcmilter/arcmilter.yaml.sample
@@ -33,8 +33,8 @@ Domains:
     DKIM: true
     ARC: true
 
-  # ワイルドカードパターン：*.example.com は example.com および sub.example.com にマッチ
-  # "example.com" は上記で定義済みなので、完全一致が優先されます
+  # ワイルドカードパターン：*.example.net は example.net および sub.example.net にマッチ
+  # "example.jp" または "example.com" は上記で定義済みなので、完全一致が優先されます
   "*.example.net":
     HeaderCanonicalization: "relaxed"
     BodyCanonicalization: "relaxed"

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -61,8 +62,9 @@ type Domain struct {
 	Selector               string `yaml:"Selector"`
 	ARCSelector            string `yaml:"ARCSelector"`
 	Domain                 string
-	DKIM                   bool `yaml:"DKIM"`
-	ARC                    bool `yaml:"ARC"`
+	Pattern                string // Original pattern from config (e.g., "*.example.com")
+	DKIM                   bool   `yaml:"DKIM"`
+	ARC                    bool   `yaml:"ARC"`
 }
 
 func getUid(userStr string) (int, error) {
@@ -199,6 +201,9 @@ func Load(path string) (*Config, error) {
 	if len(config.Domains) == 0 {
 		return nil, errors.New("domains is not set")
 	}
+	// 簡略構文を展開
+	config.Domains = expandDomains(config.Domains)
+
 	// Domainsを読み込む
 	for domain, value := range config.Domains {
 		// PrivateKeyを読み込む
@@ -275,12 +280,16 @@ func Load(path string) (*Config, error) {
 			value.ARCSelector = value.Selector
 		}
 
+		// PatternはexpandDomainsで既に設定されている
+		if value.Pattern == "" {
+			value.Pattern = domain
+		}
+		// DomainはexpandDomainsで既に設定されているが、念のため再設定
 		value.Domain = domain
+
 		config.Domains[domain] = value
 
 	}
-
-	// UserをUIDに変換
 	uid, err := getUid(config.User)
 	if err != nil {
 		return nil, err
@@ -318,4 +327,108 @@ func (c *Config) IsMyNetwork(ip net.IP) bool {
 		}
 	}
 	return false
+}
+
+// parseDomainPattern はドメインパターンを解析する
+// "example.com" → {isWildcard: false, hostPart: "example.com"}
+// "*.example.com" → {isWildcard: true, hostPart: "example.com"}
+// "*" → {isWildcard: true, hostPart: ""}
+func parseDomainPattern(pattern string) (isWildcard bool, hostPart string) {
+	if strings.HasPrefix(pattern, "*.") {
+		isWildcard = true
+		hostPart = pattern[2:] // Remove "*."
+	} else if pattern == "*" {
+		isWildcard = true
+		hostPart = ""
+	} else {
+		isWildcard = false
+		hostPart = pattern
+	}
+	return
+}
+
+// matchDomain はドメインパターンが対象ドメインにマッチするか判定する
+func matchDomain(pattern string, domain string) bool {
+	isWildcard, hostPart := parseDomainPattern(pattern)
+
+	if !isWildcard {
+		return pattern == domain
+	}
+
+	if pattern == "*" {
+		return true
+	}
+
+	// ワイルドカード: *.example.com → sub.example.com をマッチ
+	// また、example.com 自体もマッチさせる（edge case）
+	return strings.HasSuffix(domain, "."+hostPart) || domain == hostPart
+}
+
+// expandDomains は簡略構文 "label:domain1,domain2,domain3" を展開する
+func expandDomains(domains map[string]Domain) map[string]Domain {
+	result := make(map[string]Domain)
+
+	for domainKey, domainConf := range domains {
+		// 簡略構文チェック "list:example.com,*.example.com"
+		if strings.Contains(domainKey, ":") {
+			parts := strings.SplitN(domainKey, ":", 2)
+			domainList := strings.Split(parts[1], ",")
+			for _, d := range domainList {
+				d = strings.TrimSpace(d)
+				if d == "" {
+					continue
+				}
+				copy := domainConf
+				copy.Domain = d
+				copy.Pattern = d
+				result[d] = copy
+			}
+		} else {
+			// 通常の構造
+			domainConf.Domain = domainKey
+			domainConf.Pattern = domainKey
+			result[domainKey] = domainConf
+		}
+	}
+
+	return result
+}
+
+// GetMatchingDomain は対象ドメインに最もマッチするドメイン設定を返す
+// 優先順位: 完全一致 → ワイルドカード一致（より限定的なもの優先） → デフォルト(*)
+func (c *Config) GetMatchingDomain(domain string) (*Domain, bool) {
+	// 完全一致を優先
+	if d, ok := c.Domains[domain]; ok {
+		return &d, true
+	}
+
+	// ワイルドカード一致を検索（最も限定的なものを優先）
+	var bestMatch *Domain
+	bestMatchLen := 0
+
+	for pattern, d := range c.Domains {
+		if pattern == "*" {
+			continue // デフォルトは最後にチェック
+		}
+		if matchDomain(pattern, domain) {
+			_, hostPart := parseDomainPattern(pattern)
+			matchLen := len(hostPart)
+			// より長いホストパーツ（より限定的）を優先
+			if matchLen > bestMatchLen {
+				bestMatch = &d
+				bestMatchLen = matchLen
+			}
+		}
+	}
+
+	if bestMatch != nil {
+		return bestMatch, true
+	}
+
+	// デフォルト
+	if d, ok := c.Domains["*"]; ok {
+		return &d, true
+	}
+
+	return nil, false
 }

--- a/config/config.go
+++ b/config/config.go
@@ -364,15 +364,14 @@ func matchDomain(pattern string, domain string) bool {
 	return strings.HasSuffix(domain, "."+hostPart) || domain == hostPart
 }
 
-// expandDomains は簡略構文 "label:domain1,domain2,domain3" を展開する
+// expandDomains は簡略構文 "list:domain1,domain2,*.domain3" を展開する
 func expandDomains(domains map[string]Domain) map[string]Domain {
 	result := make(map[string]Domain)
 
 	for domainKey, domainConf := range domains {
 		// 簡略構文チェック "list:example.com,*.example.com"
-		if strings.Contains(domainKey, ":") {
-			parts := strings.SplitN(domainKey, ":", 2)
-			domainList := strings.Split(parts[1], ",")
+		if strings.HasPrefix(domainKey, "list:") {
+			domainList := strings.Split(domainKey[5:], ",") // "list:"の5文字をスキップ
 			for _, d := range domainList {
 				d = strings.TrimSpace(d)
 				if d == "" {
@@ -381,6 +380,7 @@ func expandDomains(domains map[string]Domain) map[string]Domain {
 				copy := domainConf
 				copy.Domain = d
 				copy.Pattern = d
+				// 重複している場合は後の設定で上書き
 				result[d] = copy
 			}
 		} else {
@@ -396,6 +396,7 @@ func expandDomains(domains map[string]Domain) map[string]Domain {
 
 // GetMatchingDomain は対象ドメインに最もマッチするドメイン設定を返す
 // 優先順位: 完全一致 → ワイルドカード一致（より限定的なもの優先） → デフォルト(*)
+// 返されるDomainのDomainフィールドは、マッチした実際のドメイン名に設定される
 func (c *Config) GetMatchingDomain(domain string) (*Domain, bool) {
 	// 完全一致を優先
 	if d, ok := c.Domains[domain]; ok {
@@ -403,10 +404,10 @@ func (c *Config) GetMatchingDomain(domain string) (*Domain, bool) {
 	}
 
 	// ワイルドカード一致を検索（最も限定的なものを優先）
-	var bestMatch *Domain
+	bestMatchKey := ""
 	bestMatchLen := 0
 
-	for pattern, d := range c.Domains {
+	for pattern := range c.Domains {
 		if pattern == "*" {
 			continue // デフォルトは最後にチェック
 		}
@@ -415,18 +416,22 @@ func (c *Config) GetMatchingDomain(domain string) (*Domain, bool) {
 			matchLen := len(hostPart)
 			// より長いホストパーツ（より限定的）を優先
 			if matchLen > bestMatchLen {
-				bestMatch = &d
+				bestMatchKey = pattern
 				bestMatchLen = matchLen
 			}
 		}
 	}
 
-	if bestMatch != nil {
-		return bestMatch, true
+	if bestMatchKey != "" {
+		if d, ok := c.Domains[bestMatchKey]; ok {
+			d.Domain = domain // マッチした実際のドメイン名を設定
+			return &d, true
+		}
 	}
 
 	// デフォルト
 	if d, ok := c.Domains["*"]; ok {
+		d.Domain = domain // マッチした実際のドメイン名を設定
 		return &d, true
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -368,8 +368,8 @@ func matchDomain(pattern string, domain string) bool {
 func expandDomains(domains map[string]Domain) map[string]Domain {
 	result := make(map[string]Domain)
 
+	// 第一フェーズ: list構文のみを展開
 	for domainKey, domainConf := range domains {
-		// 簡略構文チェック "list:example.com,*.example.com"
 		if strings.HasPrefix(domainKey, "list:") {
 			domainList := strings.Split(domainKey[5:], ",") // "list:"の5文字をスキップ
 			for _, d := range domainList {
@@ -377,14 +377,17 @@ func expandDomains(domains map[string]Domain) map[string]Domain {
 				if d == "" {
 					continue
 				}
-				copy := domainConf
-				copy.Domain = d
-				copy.Pattern = d
-				// 重複している場合は後の設定で上書き
-				result[d] = copy
+				domainCopy := domainConf
+				domainCopy.Domain = d
+				domainCopy.Pattern = d
+				result[d] = domainCopy
 			}
-		} else {
-			// 通常の構造
+		}
+	}
+
+	// 第二フェーズ: 明示的なキーを適用（list構文の設定を上書き）
+	for domainKey, domainConf := range domains {
+		if !strings.HasPrefix(domainKey, "list:") {
 			domainConf.Domain = domainKey
 			domainConf.Pattern = domainKey
 			result[domainKey] = domainConf

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -262,7 +262,7 @@ func Test_matchDomain(t *testing.T) {
 
 func Test_expandDomains(t *testing.T) {
 	input := map[string]Domain{
-		"list:example.com,mail.example.com,*.sub.example.com": {
+		"list:example.com,mail.example.com": {
 			Selector:       "default",
 			PrivateKeyFile: "/etc/arcmilter/keys/default.key",
 			DKIM:           true,
@@ -279,12 +279,12 @@ func Test_expandDomains(t *testing.T) {
 	result := expandDomains(input)
 
 	// 展開されたエントリを確認
-	if len(result) != 4 {
-		t.Errorf("expected 4 domains, got %d", len(result))
+	if len(result) != 3 {
+		t.Errorf("expected 3 domains, got %d", len(result))
 	}
 
 	// 個別のドメイン確認
-	for _, domain := range []string{"example.com", "mail.example.com", "*.sub.example.com"} {
+	for _, domain := range []string{"example.com", "mail.example.com"} {
 		if d, ok := result[domain]; !ok {
 			t.Errorf("domain %s not found in result", domain)
 		} else {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -158,3 +158,229 @@ func Test_checkMilterListenNetwork(t *testing.T) {
 		})
 	}
 }
+
+func Test_parseDomainPattern(t *testing.T) {
+	testCases := []struct {
+		name       string
+		pattern    string
+		expectWild bool
+		expectHost string
+	}{
+		{
+			name:       "exact match",
+			pattern:    "example.com",
+			expectWild: false,
+			expectHost: "example.com",
+		},
+		{
+			name:       "wildcard subdomain",
+			pattern:    "*.example.com",
+			expectWild: true,
+			expectHost: "example.com",
+		},
+		{
+			name:       "default wildcard",
+			pattern:    "*",
+			expectWild: true,
+			expectHost: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			isWild, hostPart := parseDomainPattern(tc.pattern)
+			if isWild != tc.expectWild {
+				t.Errorf("expected isWildcard=%v, got %v", tc.expectWild, isWild)
+			}
+			if hostPart != tc.expectHost {
+				t.Errorf("expected hostPart=%s, got %s", tc.expectHost, hostPart)
+			}
+		})
+	}
+}
+
+func Test_matchDomain(t *testing.T) {
+	testCases := []struct {
+		name     string
+		pattern  string
+		domain   string
+		expected bool
+	}{
+		{
+			name:     "exact match",
+			pattern:  "example.com",
+			domain:   "example.com",
+			expected: true,
+		},
+		{
+			name:     "exact mismatch",
+			pattern:  "example.com",
+			domain:   "sub.example.com",
+			expected: false,
+		},
+		{
+			name:     "wildcard matches subdomain",
+			pattern:  "*.example.com",
+			domain:   "sub.example.com",
+			expected: true,
+		},
+		{
+			name:     "wildcard matches deep subdomain",
+			pattern:  "*.example.com",
+			domain:   "mail.sub.example.com",
+			expected: true,
+		},
+		{
+			name:     "wildcard edge case matches exact domain",
+			pattern:  "*.example.com",
+			domain:   "example.com",
+			expected: true,
+		},
+		{
+			name:     "wildcard does not match different domain",
+			pattern:  "*.example.com",
+			domain:   "other.com",
+			expected: false,
+		},
+		{
+			name:     "default wildcard matches anything",
+			pattern:  "*",
+			domain:   "anything",
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := matchDomain(tc.pattern, tc.domain)
+			if result != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func Test_expandDomains(t *testing.T) {
+	input := map[string]Domain{
+		"list:example.com,mail.example.com,*.sub.example.com": {
+			Selector:       "default",
+			PrivateKeyFile: "/etc/arcmilter/keys/default.key",
+			DKIM:           true,
+			ARC:            true,
+		},
+		"exact.com": {
+			Selector:       "exact",
+			PrivateKeyFile: "/etc/arcmilter/keys/exact.key",
+			DKIM:           true,
+			ARC:            true,
+		},
+	}
+
+	result := expandDomains(input)
+
+	// 展開されたエントリを確認
+	if len(result) != 4 {
+		t.Errorf("expected 4 domains, got %d", len(result))
+	}
+
+	// 個別のドメイン確認
+	for _, domain := range []string{"example.com", "mail.example.com", "*.sub.example.com"} {
+		if d, ok := result[domain]; !ok {
+			t.Errorf("domain %s not found in result", domain)
+		} else {
+			if d.Selector != "default" {
+				t.Errorf("domain %s: expected Selector=default, got %s", domain, d.Selector)
+			}
+			if d.Domain != domain {
+				t.Errorf("domain %s: expected Domain=%s, got %s", domain, domain, d.Domain)
+			}
+			if d.Pattern != domain {
+				t.Errorf("domain %s: expected Pattern=%s, got %s", domain, domain, d.Pattern)
+			}
+		}
+	}
+
+	// 完全一致ドメインの確認
+	if d, ok := result["exact.com"]; !ok {
+		t.Errorf("domain exact.com not found in result")
+	} else {
+		if d.Selector != "exact" {
+			t.Errorf("domain exact.com: expected Selector=exact, got %s", d.Selector)
+		}
+	}
+}
+
+func Test_GetMatchingDomain(t *testing.T) {
+	testConfig := &Config{
+		Domains: map[string]Domain{
+			"example.com": {
+				Domain:         "example.com",
+				Pattern:        "example.com",
+				Selector:       "exact",
+				PrivateKeyFile: "/tmp/keys/exact.key",
+				DKIM:           true,
+			},
+			"*.customer.com": {
+				Domain:         "*.customer.com",
+				Pattern:        "*.customer.com",
+				Selector:       "customer",
+				PrivateKeyFile: "/tmp/keys/customer.key",
+				DKIM:           true,
+			},
+			"*.sub.customer.com": {
+				Domain:         "*.sub.customer.com",
+				Pattern:        "*.sub.customer.com",
+				Selector:       "subcustomer",
+				PrivateKeyFile: "/tmp/keys/subcustomer.key",
+				DKIM:           true,
+			},
+			"*": {
+				Domain:         "*",
+				Pattern:        "*",
+				Selector:       "default",
+				PrivateKeyFile: "/tmp/keys/default.key",
+				DKIM:           true,
+			},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		domain        string
+		expectPattern string
+	}{
+		{
+			name:          "exact match takes priority",
+			domain:        "example.com",
+			expectPattern: "example.com",
+		},
+		{
+			name:          "wildcard match",
+			domain:        "mail.customer.com",
+			expectPattern: "*.customer.com",
+		},
+		{
+			name:          "more specific wildcard match",
+			domain:        "mail.sub.customer.com",
+			expectPattern: "*.sub.customer.com",
+		},
+		{
+			name:          "default wildcard match",
+			domain:        "other.com",
+			expectPattern: "*",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			domain, ok := testConfig.GetMatchingDomain(tc.domain)
+			if !ok {
+				t.Errorf("domain %s: expected match, got none", tc.domain)
+				return
+			}
+			if domain.Pattern != tc.expectPattern {
+				t.Errorf("domain %s: expected pattern %s, got %s", tc.domain, tc.expectPattern, domain.Pattern)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
Issue #11 のルックアップテーブル機能（ドメインパターンマッチング）を実装しました。現行の`Domains`構造を拡張し、ワイルドカードパターン、デフォルト設定、複数ドメイン一括指定の機能を追加しました。

## 変更内容

### 新しい構文
- **完全一致**: `"example.jp"` - 特定のドメインのみにマッチ
- **ワイルドカード**: `"*.example.jp"` - example.jpおよびすべてのサブドメインにマッチ
- **デフォルト**: `"*"` - どのパターンにもマッチしない場合に使用
- **複数ドメイン構文**: `"list:domain1,domain2,*.domain3"` - カンマ区切りで複数指定

### マッチング優先順位
完全一致 > ワイルドカード（より具体的なもの）> デフォルト

### 実装した機能
- [`config/config.go`](config/config.go:65): `Domain`構造体に`Pattern`フィールド追加
  - `parseDomainPattern()`: パターン解析
  - `matchDomain()`: ドメインマッチング判定
  - `expandDomains()`: `"list:"`構文の展開
  - `GetMatchingDomain()`: 公開マッチング関数
- [`arcmilter/arcmilter.go`](arcmilter/arcmilter.go:182): `DKIMSign`、[`RcptTo`](arcmilter/arcmilter.go:113)、[`ARCSign`](arcmilter/arcmilter.go:230)関数を更新
- [`config/config_test.go`](config/config_test.go): テスト追加（4つのテスト関数）
- [`cmd/arcmilter/arcmilter.yaml.sample`](cmd/arcmilter/arcmilter.yaml.sample): サンプル設定更新
- [`README.ja.md`](README.ja.md:76), [`README.md`](README.md:75): ドキュメント追加

## 後方互換性
既存の完全一致ドメイン設定はそのまま動作します。