### PR TITLE
設定読み込みを整理し署名処理のガードを追加

### DIFF
--- a/arcmilter/arcmilter.go
+++ b/arcmilter/arcmilter.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"fmt"
 	"log"
 	"net"
 	"net/rpc"
@@ -66,14 +67,18 @@ func (a *ARCMilter) SetDebug(dbg bool) {
 	debug = dbg
 }
 
-func debugLog(format string, v ...interface{}) {
+func (s *Session) logError(format string, v ...interface{}) {
+	log.Printf("arcmilter: "+format, v...)
+}
+
+func (s *Session) debugLog(format string, v ...interface{}) {
 	if debug {
-		log.Printf(format, v...)
+		log.Printf("arcmilter: "+format, v...)
 	}
 }
 
 func (s *Session) Connect(host string, family string, port uint16, addr string, m *milter.Modifier) (*milter.Response, error) {
-	debugLog("Connect: %s", addr)
+	s.debugLog("Connect: %s", addr)
 	if ip := net.ParseIP(addr); ip != nil {
 		s.remoteAddr = ip
 	}
@@ -81,7 +86,7 @@ func (s *Session) Connect(host string, family string, port uint16, addr string, 
 }
 
 func (s *Session) Helo(name string, m *milter.Modifier) (*milter.Response, error) {
-	debugLog("Helo: %s", name)
+	s.debugLog("Helo: %s", name)
 	s.helo = name
 	return milter.RespContinue, nil
 }
@@ -89,81 +94,99 @@ func (s *Session) Helo(name string, m *milter.Modifier) (*milter.Response, error
 func (s *Session) MailFrom(from string, esmtpArgs string, m *milter.Modifier) (*milter.Response, error) {
 	s.authn = m.Macros.Get(milter.MacroAuthAuthen)
 	s.mailFrom = from
-	debugLog("MailFrom: %s", from)
+	s.debugLog("MailFrom: %s", from)
 	return milter.RespContinue, nil
 }
 
 func (s *Session) RcptTo(rcptTo string, esmtpArgs string, m *milter.Modifier) (*milter.Response, error) {
-	debugLog("RcptTo: %s", rcptTo)
+	s.debugLog("RcptTo: %s", rcptTo)
 	s.mmauth = mmauth.NewMMAuth()
-	// SMTP認証済みもしくはIPアドレスがMyNetworksに含まれている場合はARC署名を行わない
+
+	// SMTP 認証済みもしくは IP アドレスが MyNetworks に含まれている場合は署名を行わない
 	if s.authn != "" || s.conf.IsMyNetwork(s.remoteAddr) {
 		return milter.RespContinue, nil
 	}
+
 	rpctToDomain, err := mmauth.ParseAddressDomain(rcptTo)
 	if err != nil {
-		log.Printf("util.ParseAddressDomain: %v", err)
+		s.logError("util.ParseAddressDomain: %v", err)
 		return milter.RespContinue, nil
 	}
 	s.rcptToDomain = rpctToDomain
-	// 署名の準備
+
+	// 宛先が対象ドメインなら ARC 署名と BodyHash を設定
 	if domain, ok := s.conf.GetMatchingDomain(rpctToDomain); ok {
-		// 宛先が対象ドメインならARC署名を行う
 		s.isARCSign = true
-		s.mmauth.AddBodyHash(mmauth.BodyCanonicalizationAndAlgorithm{
-			Body:      mmauth.Canonicalization(domain.BodyCanonicalization),
-			Algorithm: domain.HashAlgo,
-			Limit:     0,
-		})
+		s.mmauth.AddBodyHash(
+			createBodyHashConfig(domain.BodyCanonicalization, domain.HashAlgo, 0),
+		)
 		return milter.RespContinue, nil
 	}
+
 	return milter.RespContinue, nil
 }
 
 func (s *Session) Header(name, value string, m *milter.Modifier) (*milter.Response, error) {
 	s.mmauth.Write([]byte(name + ": " + value + "\r\n"))
-	switch strings.ToLower(name) {
-	case "from":
-		s.from = value
-		fromDomain, err := mmauth.ParseAddressDomain(value)
-		if err != nil {
-			log.Printf("util.ParseAddressDomain: %v", err)
-			s.isDKIMSign = false
-			return milter.RespContinue, nil
-		}
-		s.fromDomain = fromDomain
 
-		if domain, ok := s.conf.GetMatchingDomain(s.fromDomain); ok && domain.DKIM {
-			// 送信元が対象ドメインなら正規化とハッシュアルゴリズムを設定
-			s.mmauth.AddBodyHash(mmauth.BodyCanonicalizationAndAlgorithm{
-				Body:      mmauth.Canonicalization(domain.BodyCanonicalization),
-				Algorithm: domain.HashAlgo,
-				Limit:     0,
-			})
-			// DKIM署名を行う
-			s.isDKIMSign = true
-		} else {
-			s.isDKIMSign = false
-		}
+	if strings.ToLower(name) != "from" {
 		return milter.RespContinue, nil
+	}
+
+	s.from = value
+	fromDomain, err := mmauth.ParseAddressDomain(value)
+	if err != nil {
+		s.logError("util.ParseAddressDomain: %v", err)
+		s.isDKIMSign = false
+		return milter.RespContinue, nil
+	}
+	s.fromDomain = fromDomain
+
+	// 送信元が対象ドメインなら DKIM 署名設定
+	if domain, ok := s.conf.GetMatchingDomain(s.fromDomain); ok && domain.DKIM {
+		s.mmauth.AddBodyHash(createBodyHashConfig(domain.BodyCanonicalization, domain.HashAlgo, 0))
+		s.isDKIMSign = true
+	} else {
+		s.isDKIMSign = false
 	}
 
 	return milter.RespContinue, nil
 }
 
 func (s *Session) Headers(m *milter.Modifier) (*milter.Response, error) {
-	debugLog("Headers")
+	s.debugLog("Headers")
 	if _, err := s.mmauth.Write([]byte("\r\n")); err != nil {
-		log.Printf("s.mmauth.Write: %v", err)
+		s.logError("s.mmauth.Write: %v", err)
 	}
 	return milter.RespContinue, nil
 }
 
 func (s *Session) BodyChunk(chunk []byte, m *milter.Modifier) (*milter.Response, error) {
 	if _, err := s.mmauth.Write(chunk); err != nil {
-		log.Printf("s.mmauth.Write: %v", err)
+		s.logError("s.mmauth.Write: %v", err)
 	}
 	return milter.RespContinue, nil
+}
+
+// getKeyTypeAlgo は公開鍵のタイプから DKIM 署名アルゴリズムを判定する
+func getKeyTypeAlgo(pub interface{}) (dkim.SignatureAlgorithm, error) {
+	switch pub.(type) {
+	case *rsa.PublicKey:
+		return dkim.SignatureAlgorithmRSA_SHA256, nil
+	case ed25519.PublicKey:
+		return dkim.SignatureAlgorithmED25519_SHA256, nil
+	default:
+		return "", fmt.Errorf("unknown key type: %T", pub)
+	}
+}
+
+// createBodyHashConfig は BodyHash の設定用構造体を生成する
+func createBodyHashConfig(canonicalization string, hashAlgo crypto.Hash, limit int64) mmauth.BodyCanonicalizationAndAlgorithm {
+	return mmauth.BodyCanonicalizationAndAlgorithm{
+		Body:      mmauth.Canonicalization(canonicalization),
+		Algorithm: hashAlgo,
+		Limit:     limit,
+	}
 }
 
 func DKIMSign(s *Session, m *milter.Modifier) {
@@ -172,31 +195,26 @@ func DKIMSign(s *Session, m *milter.Modifier) {
 	}
 
 	if h := mmauth.ExtractHeadersDKIM(s.mmauth.Headers, []string{"DKIM-Signature"}); len(h) > 0 {
-		// すでにDKIM署名がある場合はDKIM署名しない
-		log.Print("DKIM-Signature found Skip")
+		// すでに DKIM 署名がある場合は DKIM 署名しない
+		s.logError("DKIM-Signature found Skip")
 		return
 	}
 
-	// 対応するドメインのキーがある場合はDKIM署名を行う
+	// 対応するドメインのキーがある場合は DKIM 署名を行う
 	if domain, ok := s.conf.GetMatchingDomain(s.fromDomain); ok && domain.DKIM {
-		bodyHash := s.mmauth.GetBodyHash(mmauth.BodyCanonicalizationAndAlgorithm{
-			Body:      mmauth.Canonicalization(domain.BodyCanonicalization),
-			Algorithm: domain.HashAlgo,
-			Limit:     0,
-		})
-
-		var algo dkim.SignatureAlgorithm
-		switch domain.PrivateKeySigner.Public().(type) {
-		case *rsa.PublicKey:
-			algo = dkim.SignatureAlgorithmRSA_SHA256
-		case ed25519.PublicKey:
-			algo = dkim.SignatureAlgorithmED25519_SHA256
-		default:
-			log.Printf("unknown key type: %T", domain.PrivateKeySigner)
+		bodyHash := s.mmauth.GetBodyHash(createBodyHashConfig(domain.BodyCanonicalization, domain.HashAlgo, 0))
+		if bodyHash == "" {
+			s.logError("DKIM body hash is empty")
 			return
 		}
 
-		// DKIM署名
+		algo, err := getKeyTypeAlgo(domain.PrivateKeySigner.Public())
+		if err != nil {
+			s.logError("%v", err)
+			return
+		}
+
+		// DKIM 署名
 		dkim := dkim.Signature{
 			Algorithm:        algo,
 			Signature:        "",
@@ -209,12 +227,12 @@ func DKIMSign(s *Session, m *milter.Modifier) {
 
 		if err := dkim.Sign(mmauth.ExtractHeadersDKIM(s.mmauth.Headers, s.conf.DKIMSignHeaders),
 			domain.PrivateKeySigner); err != nil {
-			log.Printf("dkim.Sign: %v", err)
+			s.logError("dkim.Sign: %v", err)
 			return
 		}
 
 		if err := m.InsertHeader(1, "DKIM-Signature", dkim.String()); err != nil {
-			log.Printf("DKIM Signature Insert Error: %v", err)
+			s.logError("DKIM Signature Insert Error: %v", err)
 			return
 		}
 		s.mmauth.Headers = append(s.mmauth.Headers, "DKIM-Signature: "+dkim.String())
@@ -228,46 +246,46 @@ func ARCSign(s *Session, m *milter.Modifier) {
 
 	if domain, ok := s.conf.GetMatchingDomain(s.rcptToDomain); ok && domain.ARC {
 		if s.mmauth.AuthenticationHeaders == nil {
-			log.Printf("AuthenticationHeaders is nil")
+			s.logError("AuthenticationHeaders is nil")
+			return
 		}
 		ah := s.mmauth.AuthenticationHeaders.ARCSignatures
 
-		// ARC-Chain-Validation-Resultがfailの場合はARC署名を行わない
+		// ARC-Chain-Validation-Result が fail の場合は ARC 署名を行わない
 		if ah.GetARCChainValidation() == arc.ChainValidationResultFail {
-			log.Printf("ARC-Chain-Validation-Result is fail skip ARC signing")
+			s.logError("ARC-Chain-Validation-Result is fail skip ARC signing")
 			return
 		}
 
-		var algo arc.SignatureAlgorithm
+		// 署名アルゴリズムの判定
+		var arcAlgo arc.SignatureAlgorithm
 		switch domain.PrivateKeySigner.Public().(type) {
 		case *rsa.PublicKey:
-			algo = arc.SignatureAlgorithmRSA_SHA256
+			arcAlgo = arc.SignatureAlgorithmRSA_SHA256
 		case ed25519.PublicKey:
-			algo = arc.SignatureAlgorithmED25519_SHA256
+			arcAlgo = arc.SignatureAlgorithmED25519_SHA256
 		default:
-			log.Printf("unknown key type: %T", domain.PrivateKeySigner)
+			s.logError("unknown key type: %T", domain.PrivateKeySigner)
 			return
 		}
 
 		instanceNumber := ah.GetMaxInstance() + 1
 		signature := arc.ARCMessageSignature{
 			InstanceNumber:   instanceNumber,
-			Algorithm:        algo,
+			Algorithm:        arcAlgo,
 			Domain:           s.rcptToDomain,
 			Selector:         domain.ARCSelector,
 			Canonicalization: domain.HeaderCanonicalization + "/" + domain.BodyCanonicalization,
-			BodyHash: s.mmauth.GetBodyHash(
-				mmauth.BodyCanonicalizationAndAlgorithm{
-					Body:      mmauth.CanonicalizationRelaxed,
-					Algorithm: crypto.SHA256,
-					Limit:     0,
-				},
-			),
+			BodyHash:         s.mmauth.GetBodyHash(createBodyHashConfig(domain.BodyCanonicalization, domain.HashAlgo, 0)),
+		}
+		if signature.BodyHash == "" {
+			s.logError("ARC body hash is empty")
+			return
 		}
 
 		if err := signature.Sign(mmauth.ExtractHeadersDKIM(s.mmauth.Headers, s.conf.ARCSignHeaders),
 			domain.PrivateKeySigner); err != nil {
-			log.Printf("signature.Sign: %v", err)
+			s.logError("signature.Sign: %v", err)
 			return
 		}
 
@@ -278,10 +296,10 @@ func ARCSign(s *Session, m *milter.Modifier) {
 			Results:        results,
 		}
 
-		// ARC-Seal署名
+		// ARC-Seal 署名
 		seal := arc.ARCSeal{
 			InstanceNumber: instanceNumber,
-			Algorithm:      algo,
+			Algorithm:      arcAlgo,
 			Domain:         s.rcptToDomain,
 			Selector:       domain.ARCSelector,
 			ChainValidation: arc.ChainValidationResult(
@@ -293,66 +311,66 @@ func ARCSign(s *Session, m *milter.Modifier) {
 		headers = append(headers, "ARC-Message-Signature: "+signature.String())
 
 		if err := seal.Sign(headers, domain.PrivateKeySigner); err != nil {
-			log.Printf("seal.Sign: %v", err)
+			s.logError("seal.Sign: %v", err)
 			return
 		}
 
 		if err := m.InsertHeader(1, "ARC-Authentication-Results", result.String()); err != nil {
-			log.Printf("ARC-Authentication-Results Insert Error: %v", err)
+			s.logError("ARC-Authentication-Results Insert Error: %v", err)
 			return
 		}
 		if err := m.InsertHeader(1, "ARC-Message-Signature", signature.String()); err != nil {
-			log.Printf("ARC-Message-Signature Insert Error: %v", err)
+			s.logError("ARC-Message-Signature Insert Error: %v", err)
 			return
 		}
 		if err := m.InsertHeader(1, "ARC-Seal", seal.String()); err != nil {
-			log.Printf("ARC-Seal Insert Error: %v", err)
+			s.logError("ARC-Seal Insert Error: %v", err)
 			return
 		}
 	}
 }
 
 func (s *Session) EndOfMessage(m *milter.Modifier) (*milter.Response, error) {
-	debugLog("EndOfMessage")
+	s.debugLog("EndOfMessage")
 	if s.mmauth == nil {
 		return milter.RespContinue, nil
 	}
 	if err := s.mmauth.Close(); err != nil {
-		log.Printf("s.mmauth.Close: %v", err)
+		s.logError("s.mmauth.Close: %v", err)
 		return milter.RespContinue, nil
 	}
 
 	// Verify
 	s.mmauth.Verify()
 
-	// DKIM署名
+	// DKIM 署名
 	DKIMSign(s, m)
 
-	// ARC署名
+	// ARC 署名
 	ARCSign(s, m)
 
-	debugLog("session: %s", pp.Sprint(s))
+	s.debugLog("session: %s", pp.Sprint(s))
 
 	return milter.RespContinue, nil
 }
 
 func (s *Session) Abort(_ *milter.Modifier) error {
-	debugLog("Abort")
+	s.debugLog("Abort")
 
 	if s.mmauth != nil {
 		if err := s.mmauth.Close(); err != nil {
-			log.Printf("s.mmauth.Close: %v", err)
+			s.logError("s.mmauth.Close: %v", err)
 		}
 	}
 	return nil
 }
 
 func (s *Session) Cleanup() {
-	debugLog("Cleanup")
+	s.debugLog("Cleanup")
 
 	if s.mmauth != nil {
 		if err := s.mmauth.Close(); err != nil {
-			log.Printf("s.mmauth.Close: %v", err)
+			s.logError("s.mmauth.Close: %v", err)
 		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -16,6 +15,22 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+const (
+	DefaultHeaderCanonicalization = "relaxed"
+	DefaultBodyCanonicalization   = "relaxed"
+	DefaultHashAlgorithm          = "sha256"
+	DefaultSelector               = "default"
+)
+
+type ConfigError struct {
+	Field   string
+	Message string
+}
+
+func (e *ConfigError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
 
 type Config struct {
 	Path    string
@@ -68,7 +83,6 @@ type Domain struct {
 }
 
 func getUid(userStr string) (int, error) {
-	// 空の場合は自分自身のUIDを取得
 	var uidStr string
 	if userStr == "" {
 		u, err := user.Current()
@@ -91,7 +105,6 @@ func getUid(userStr string) (int, error) {
 }
 
 func getGid(groupStr string) (int, error) {
-	// 空の場合は自分自身のGIDを取得
 	var gidStr string
 	if groupStr == "" {
 		g, err := user.Current()
@@ -123,97 +136,203 @@ func checkMilterListenNetwork(network string) error {
 }
 
 func Load(path string) (*Config, error) {
+	config := createDefaultConfig()
+
 	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	// YAMLをパースする
-	var config Config
-	err = yaml.Unmarshal(buf, &config)
+	err = parseYAML(buf, config)
 	if err != nil {
 		return nil, err
 	}
 
-	// MilterListen Networkのバリデーション
-	if err := checkMilterListenNetwork(config.MilterListen.Network); err != nil {
+	err = validateConfig(config)
+	if err != nil {
 		return nil, err
 	}
 
-	// UnixSocketの場合はOwnerとGroupを設定
+	err = loadKeys(config)
+	if err != nil {
+		return nil, err
+	}
+
+	config.Path = path
+	return config, nil
+}
+
+func createDefaultConfig() *Config {
+	return &Config{
+		MilterListen: struct {
+			Network string `yaml:"Network"`
+			Address string `yaml:"Address"`
+			Mode    uint32 `yaml:"Mode"`
+			Owner   string `yaml:"Owner"`
+			Group   string `yaml:"Group"`
+			Uid     int
+			Gid     int
+		}{},
+		ControlSocketFile: struct {
+			Path string `yaml:"Path"`
+			Mode uint32 `yaml:"Mode"`
+		}{},
+		LogFile: struct {
+			Path string `yaml:"Path"`
+			Mode uint32 `yaml:"Mode"`
+		}{},
+		Domains:          make(map[string]Domain),
+		ParsedMyNetworks: make([]*net.IPNet, 0),
+		ARCSignHeaders:   make([]string, 0),
+		DKIMSignHeaders:  make([]string, 0),
+	}
+}
+
+func parseYAML(buf []byte, config *Config) error {
+	err := yaml.Unmarshal(buf, config)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateConfig(config *Config) error {
+	if err := checkMilterListenNetwork(config.MilterListen.Network); err != nil {
+		return err
+	}
+
 	if config.MilterListen.Network == "unix" {
 		uid, err := getUid(config.MilterListen.Owner)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		config.MilterListen.Uid = uid
 		gid, err := getGid(config.MilterListen.Group)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		config.MilterListen.Gid = gid
 	}
 
-	// MilterListen Addressのバリデーション
 	if config.MilterListen.Address == "" {
-		return nil, errors.New("MilterListen.Address is not set")
+		return &ConfigError{Field: "MilterListen.Address", Message: "is not set"}
 	}
 
-	// MilterListen Modeが設定されていなければ0600にする
 	if config.MilterListen.Mode == 0 {
 		config.MilterListen.Mode = 0600
 	}
 
-	// PidFile Pathが設定されているか確認
 	if config.PidFile.Path == "" {
-		return nil, errors.New("PIDFile is not set")
+		return &ConfigError{Field: "PIDFile.Path", Message: "is not set"}
 	}
 
-	// ControlSocketファイルのパスが設定されているか確認
 	if config.ControlSocketFile.Path == "" {
-		return nil, errors.New("ControlSocketFile.Path is not set")
+		return &ConfigError{Field: "ControlSocketFile.Path", Message: "is not set"}
 	}
 
-	// ControlSocket Modeが設定されていなければ0600にする
 	if config.ControlSocketFile.Mode == 0 {
 		config.ControlSocketFile.Mode = 0600
 	}
 
-	// LogFIle Modeが設定されていなければ0600にする
 	if config.LogFile.Mode == 0 {
 		config.LogFile.Mode = 0600
 	}
 
-	// MyNetworksが設定されていなければエラー
 	if len(config.MyNetworks) == 0 {
-		return nil, errors.New("MyNetwork is not set")
+		return &ConfigError{Field: "MyNetworks", Message: "is not set"}
 	}
-	// MyNetworksをパースする
+
 	for _, network := range config.MyNetworks {
 		_, ipNet, err := net.ParseCIDR(network)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		config.ParsedMyNetworks = append(config.ParsedMyNetworks, ipNet)
 	}
 
-	// Domainsが設定されていなければエラー
 	if len(config.Domains) == 0 {
-		return nil, errors.New("domains is not set")
+		return &ConfigError{Field: "Domains", Message: "is not set"}
 	}
-	// 簡略構文を展開
+
 	config.Domains = expandDomains(config.Domains)
 
-	// Domainsを読み込む
 	for domain, value := range config.Domains {
-		// PrivateKeyを読み込む
+		if value.HeaderCanonicalization == "" {
+			value.HeaderCanonicalization = DefaultHeaderCanonicalization
+		}
+		switch value.HeaderCanonicalization {
+		case "simple", "relaxed":
+		default:
+			return &ConfigError{Field: fmt.Sprintf("Domains[%s].HeaderCanonicalization", value.Domain), Message: fmt.Sprintf(`invalid value "%s"`, value.HeaderCanonicalization)}
+		}
+		if value.BodyCanonicalization == "" {
+			value.BodyCanonicalization = DefaultBodyCanonicalization
+		}
+		switch value.BodyCanonicalization {
+		case "simple", "relaxed":
+		default:
+			return &ConfigError{Field: fmt.Sprintf("Domains[%s].BodyCanonicalization", value.Domain), Message: fmt.Sprintf(`invalid value "%s"`, value.BodyCanonicalization)}
+		}
+
+		if value.HashAlgorithm == "" {
+			value.HashAlgorithm = DefaultHashAlgorithm
+		}
+		switch value.HashAlgorithm {
+		case "sha1":
+			value.HashAlgo = crypto.SHA1
+		case "sha256":
+			value.HashAlgo = crypto.SHA256
+		default:
+			return &ConfigError{Field: fmt.Sprintf("Domains[%s].HashAlgorithm", value.Domain), Message: fmt.Sprintf(`invalid value "%s"`, value.HashAlgorithm)}
+		}
+
+		if value.Selector == "" {
+			value.Selector = DefaultSelector
+		}
+		if value.ARCSelector == "" {
+			value.ARCSelector = value.Selector
+		}
+
+		if value.Pattern == "" {
+			value.Pattern = domain
+		}
+		value.Domain = domain
+
+		config.Domains[domain] = value
+	}
+
+	uid, err := getUid(config.User)
+	if err != nil {
+		return err
+	}
+	config.Uid = uid
+
+	gid, err := getGid(config.Group)
+	if err != nil {
+		return err
+	}
+	config.Gid = gid
+
+	if len(config.DKIMSignHeaders) == 0 {
+		return &ConfigError{Field: "DKIMSignHeaders", Message: "is not set"}
+	}
+
+	if len(config.ARCSignHeaders) == 0 {
+		return &ConfigError{Field: "ARCSignHeaders", Message: "is not set"}
+	}
+
+	return nil
+}
+
+func loadKeys(config *Config) error {
+	for domain, value := range config.Domains {
 		buf, err := os.ReadFile(value.PrivateKeyFile)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		block, _ := pem.Decode(buf)
 		if block == nil {
-			return nil, fmt.Errorf("failed to decode pem: %s", value.PrivateKeyFile)
+			return fmt.Errorf("failed to decode pem: %s", value.PrivateKeyFile)
 		}
 
 		var priv interface{}
@@ -221,15 +340,15 @@ func Load(path string) (*Config, error) {
 		case "RSA PRIVATE KEY":
 			priv, err = x509.ParsePKCS1PrivateKey(block.Bytes)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		case "PRIVATE KEY":
 			priv, err = x509.ParsePKCS8PrivateKey(block.Bytes)
 			if err != nil {
-				return nil, err
+				return err
 			}
 		default:
-			return nil, fmt.Errorf("unknown key type: %s", block.Type)
+			return fmt.Errorf("unknown key type: %s", block.Type)
 		}
 
 		switch key := priv.(type) {
@@ -238,88 +357,16 @@ func Load(path string) (*Config, error) {
 		case ed25519.PrivateKey:
 			value.PrivateKeySigner = key
 		default:
-			return nil, fmt.Errorf("unknown key type: %T", key)
+			return fmt.Errorf("unknown key type: %T", key)
 		}
-
-		// HeaderCanonicalizationとBodyCanonicalizationのバリデーション
-		if value.HeaderCanonicalization == "" {
-			value.HeaderCanonicalization = "relaxed"
-		}
-		switch value.HeaderCanonicalization {
-		case "simple", "relaxed":
-		default:
-			return nil, fmt.Errorf("invalid HeaderCanonicalization: %s", value.HeaderCanonicalization)
-		}
-		if value.BodyCanonicalization == "" {
-			value.BodyCanonicalization = "relaxed"
-		}
-		switch value.BodyCanonicalization {
-		case "simple", "relaxed":
-		default:
-			return nil, fmt.Errorf("invalid BodyCanonicalization: %s", value.BodyCanonicalization)
-		}
-
-		// HashAlgoのバリデーション
-		if value.HashAlgorithm == "" {
-			value.HashAlgorithm = "sha256"
-		}
-		switch value.HashAlgorithm {
-		case "sha1":
-			value.HashAlgo = crypto.SHA1
-		case "sha256":
-			value.HashAlgo = crypto.SHA256
-		default:
-			return nil, fmt.Errorf("invalid HashAlgo: %s", value.HashAlgo)
-		}
-
-		// if Selector is empty, use "default"
-		if value.Selector == "" {
-			value.Selector = "default"
-		}
-		if value.ARCSelector == "" {
-			value.ARCSelector = value.Selector
-		}
-
-		// PatternはexpandDomainsで既に設定されている
-		if value.Pattern == "" {
-			value.Pattern = domain
-		}
-		// DomainはexpandDomainsで既に設定されているが、念のため再設定
-		value.Domain = domain
 
 		config.Domains[domain] = value
-
-	}
-	uid, err := getUid(config.User)
-	if err != nil {
-		return nil, err
-	}
-	config.Uid = uid
-
-	// GroupをGIDに変換
-	gid, err := getGid(config.Group)
-	if err != nil {
-		return nil, err
-	}
-	config.Gid = gid
-
-	// DKIMSignHeadersが設定されていなければエラー
-	if len(config.DKIMSignHeaders) == 0 {
-		return nil, errors.New("DKIMSignHeaders is not set")
 	}
 
-	// ARCSignHeadersが設定されていなければエラー
-	if len(config.ARCSignHeaders) == 0 {
-		return nil, errors.New("ARCSignHeaders is not set")
-	}
-
-	// HUP用にパスを保存
-	config.Path = path
-
-	return &config, nil
+	return nil
 }
 
-// IsMyNetwork は指定されたIPアドレスが自分のネットワークに含まれるかを返す
+// IsMyNetwork は指定された IP アドレスが自分のネットワークに含まれるかを返す
 func (c *Config) IsMyNetwork(ip net.IP) bool {
 	for _, ipNet := range c.ParsedMyNetworks {
 		if ipNet.Contains(ip) {
@@ -336,7 +383,7 @@ func (c *Config) IsMyNetwork(ip net.IP) bool {
 func parseDomainPattern(pattern string) (isWildcard bool, hostPart string) {
 	if strings.HasPrefix(pattern, "*.") {
 		isWildcard = true
-		hostPart = pattern[2:] // Remove "*."
+		hostPart = pattern[2:]
 	} else if pattern == "*" {
 		isWildcard = true
 		hostPart = ""
@@ -359,8 +406,6 @@ func matchDomain(pattern string, domain string) bool {
 		return true
 	}
 
-	// ワイルドカード: *.example.com → sub.example.com をマッチ
-	// また、example.com 自体もマッチさせる（edge case）
 	return strings.HasSuffix(domain, "."+hostPart) || domain == hostPart
 }
 
@@ -368,10 +413,9 @@ func matchDomain(pattern string, domain string) bool {
 func expandDomains(domains map[string]Domain) map[string]Domain {
 	result := make(map[string]Domain)
 
-	// 第一フェーズ: list構文のみを展開
 	for domainKey, domainConf := range domains {
 		if strings.HasPrefix(domainKey, "list:") {
-			domainList := strings.Split(domainKey[5:], ",") // "list:"の5文字をスキップ
+			domainList := strings.Split(domainKey[5:], ",")
 			for _, d := range domainList {
 				d = strings.TrimSpace(d)
 				if d == "" {
@@ -385,7 +429,6 @@ func expandDomains(domains map[string]Domain) map[string]Domain {
 		}
 	}
 
-	// 第二フェーズ: 明示的なキーを適用（list構文の設定を上書き）
 	for domainKey, domainConf := range domains {
 		if !strings.HasPrefix(domainKey, "list:") {
 			domainConf.Domain = domainKey
@@ -398,26 +441,23 @@ func expandDomains(domains map[string]Domain) map[string]Domain {
 }
 
 // GetMatchingDomain は対象ドメインに最もマッチするドメイン設定を返す
-// 優先順位: 完全一致 → ワイルドカード一致（より限定的なもの優先） → デフォルト(*)
-// 返されるDomainのDomainフィールドは、マッチした実際のドメイン名に設定される
+// 優先順位：完全一致 → ワイルドカード一致（より限定的なもの優先） → デフォルト(*)
+// 返される Domain の Domain フィールドは、マッチした実際のドメイン名に設定される
 func (c *Config) GetMatchingDomain(domain string) (*Domain, bool) {
-	// 完全一致を優先
 	if d, ok := c.Domains[domain]; ok {
 		return &d, true
 	}
 
-	// ワイルドカード一致を検索（最も限定的なものを優先）
 	bestMatchKey := ""
 	bestMatchLen := 0
 
 	for pattern := range c.Domains {
 		if pattern == "*" {
-			continue // デフォルトは最後にチェック
+			continue
 		}
 		if matchDomain(pattern, domain) {
 			_, hostPart := parseDomainPattern(pattern)
 			matchLen := len(hostPart)
-			// より長いホストパーツ（より限定的）を優先
 			if matchLen > bestMatchLen {
 				bestMatchKey = pattern
 				bestMatchLen = matchLen
@@ -427,14 +467,13 @@ func (c *Config) GetMatchingDomain(domain string) (*Domain, bool) {
 
 	if bestMatchKey != "" {
 		if d, ok := c.Domains[bestMatchKey]; ok {
-			d.Domain = domain // マッチした実際のドメイン名を設定
+			d.Domain = domain
 			return &d, true
 		}
 	}
 
-	// デフォルト
 	if d, ok := c.Domains["*"]; ok {
-		d.Domain = domain // マッチした実際のドメイン名を設定
+		d.Domain = domain
 		return &d, true
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -248,6 +248,24 @@ func Test_matchDomain(t *testing.T) {
 			domain:   "anything",
 			expected: true,
 		},
+		{
+			name:     "deep wildcard matches",
+			pattern:  "*.sub.example.com",
+			domain:   "sub.example.com",
+			expected: true,
+		},
+		{
+			name:     "deep wildcard matches deep subdomain",
+			pattern:  "*.sub.example.com",
+			domain:   "mail.sub.example.com",
+			expected: true,
+		},
+		{
+			name:     "deep wildcard does not match",
+			pattern:  "*.sub.example.com",
+			domain:   "other.example.com",
+			expected: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -383,4 +401,169 @@ func Test_GetMatchingDomain(t *testing.T) {
 			}
 		})
 	}
+
+	deepWildcardConfig := &Config{
+		Domains: map[string]Domain{
+			"example.com": {
+				Domain:         "example.com",
+				Pattern:        "example.com",
+				Selector:       "exact",
+				PrivateKeyFile: "/tmp/keys/exact.key",
+				DKIM:           true,
+			},
+			"*.example.com": {
+				Domain:         "*.example.com",
+				Pattern:        "*.example.com",
+				Selector:       "wildcard",
+				PrivateKeyFile: "/tmp/keys/wildcard.key",
+				DKIM:           true,
+			},
+			"*.deep.example.com": {
+				Domain:         "*.deep.example.com",
+				Pattern:        "*.deep.example.com",
+				Selector:       "deep",
+				PrivateKeyFile: "/tmp/keys/deep.key",
+				DKIM:           true,
+			},
+			"*": {
+				Domain:         "*",
+				Pattern:        "*",
+				Selector:       "default",
+				PrivateKeyFile: "/tmp/keys/default.key",
+				DKIM:           true,
+			},
+		},
+	}
+
+	t.Run("deep wildcard priority", func(t *testing.T) {
+		d, ok := deepWildcardConfig.GetMatchingDomain("sub.deep.example.com")
+		if !ok {
+			t.Error("expected match")
+		} else if d.Pattern != "*.deep.example.com" {
+			t.Errorf("expected pattern *.deep.example.com, got %s", d.Pattern)
+		}
+	})
+
+	t.Run("wildcard priority over deep wildcard", func(t *testing.T) {
+		d, ok := deepWildcardConfig.GetMatchingDomain("sub.example.com")
+		if !ok {
+			t.Error("expected match")
+		} else if d.Pattern != "*.example.com" {
+			t.Errorf("expected pattern *.example.com, got %s", d.Pattern)
+		}
+	})
+
+	t.Run("exact priority over wildcard", func(t *testing.T) {
+		d, ok := deepWildcardConfig.GetMatchingDomain("example.com")
+		if !ok {
+			t.Error("expected match")
+		} else if d.Pattern != "example.com" {
+			t.Errorf("expected pattern example.com, got %s", d.Pattern)
+		}
+	})
+
+	t.Run("default wildcard fallback", func(t *testing.T) {
+		d, ok := deepWildcardConfig.GetMatchingDomain("random.com")
+		if !ok {
+			t.Error("expected match")
+		} else if d.Pattern != "*" {
+			t.Errorf("expected pattern *, got %s", d.Pattern)
+		}
+	})
+
+	t.Run("no match case", func(t *testing.T) {
+		// * を含まない設定でマッチしないケース
+		noDefaultConfig := &Config{
+			Domains: map[string]Domain{
+				"example.com": {
+					Domain:         "example.com",
+					Pattern:        "example.com",
+					Selector:       "exact",
+					PrivateKeyFile: "/tmp/keys/exact.key",
+					DKIM:           true,
+				},
+				"*.example.com": {
+					Domain:         "*.example.com",
+					Pattern:        "*.example.com",
+					Selector:       "wildcard",
+					PrivateKeyFile: "/tmp/keys/wildcard.key",
+					DKIM:           true,
+				},
+			},
+		}
+		_, ok := noDefaultConfig.GetMatchingDomain("nonexistent.example.org")
+		if ok {
+			t.Error("expected no match")
+		}
+	})
+
+	t.Run("multiple wildcard patterns priority", func(t *testing.T) {
+		multiConfig := &Config{
+			Domains: map[string]Domain{
+				"*.example.com": {
+					Domain:         "*.example.com",
+					Pattern:        "*.example.com",
+					Selector:       "example-com",
+					PrivateKeyFile: "/tmp/keys/example-com.key",
+					DKIM:           true,
+				},
+				"*.example.jp": {
+					Domain:         "*.example.jp",
+					Pattern:        "*.example.jp",
+					Selector:       "example-jp",
+					PrivateKeyFile: "/tmp/keys/example-jp.key",
+					DKIM:           true,
+				},
+				"*.deep.example.com": {
+					Domain:         "*.deep.example.com",
+					Pattern:        "*.deep.example.com",
+					Selector:       "deep-example-com",
+					PrivateKeyFile: "/tmp/keys/deep-example-com.key",
+					DKIM:           true,
+				},
+				"*.deep.example.jp": {
+					Domain:         "*.deep.example.jp",
+					Pattern:        "*.deep.example.jp",
+					Selector:       "deep-example-jp",
+					PrivateKeyFile: "/tmp/keys/deep-example-jp.key",
+					DKIM:           true,
+				},
+				"*": {
+					Domain:         "*",
+					Pattern:        "*",
+					Selector:       "default",
+					PrivateKeyFile: "/tmp/keys/default.key",
+					DKIM:           true,
+				},
+			},
+		}
+
+		d, ok := multiConfig.GetMatchingDomain("mail.sub.example.com")
+		if !ok {
+			t.Error("expected match")
+		} else if d.Pattern != "*.example.com" {
+			t.Errorf("expected pattern *.example.com, got %s", d.Pattern)
+		}
+
+		d, ok = multiConfig.GetMatchingDomain("mail.sub.deep.example.com")
+		if !ok {
+			t.Error("expected match")
+		} else if d.Pattern != "*.deep.example.com" {
+			t.Errorf("expected pattern *.deep.example.com, got %s", d.Pattern)
+		}
+
+		d, ok = multiConfig.GetMatchingDomain("mail.example.jp")
+		if !ok {
+			t.Error("expected match")
+		} else if d.Pattern != "*.example.jp" {
+			t.Errorf("expected pattern *.example.jp, got %s", d.Pattern)
+		}
+
+		d, ok = multiConfig.GetMatchingDomain("mail.sub.deep.example.jp")
+		if !ok {
+			t.Error("expected match")
+		} else if d.Pattern != "*.deep.example.jp" {
+			t.Errorf("expected pattern *.deep.example.jp, got %s", d.Pattern)
+		}
+	})
 }


### PR DESCRIPTION
## 概要

設定読み込み処理を整理し、DKIM/ARC 署名時の異常系ガードを追加しました。

## 変更内容

- `config.Load` の処理を YAML パース、設定検証、秘密鍵読み込みに分割
- 未使用だった `DomainSchema` 相当の処理を削除
- デフォルト値を定数化
- 設定エラー用の `ConfigError` を追加
- DKIM/ARC 署名時に BodyHash が空の場合は署名をスキップ
- ARC 署名時に `AuthenticationHeaders` が nil の場合は panic せずスキップ
- ARC の BodyHash 取得を設定済み canonicalization/hash algorithm と一致させる