### PR TITLE
GitHub Actions の参照を pinact で固定する

### DIFF
--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -4,14 +4,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.24'
       - name: Go test

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,0 +1,35 @@
+name: pinact
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".pinact.yaml"
+      - "action.yml"
+      - "action.yaml"
+      - "**/action.yml"
+      - "**/action.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: Check pinned Actions
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          config: .pinact.yaml
+          fix: "false"
+          skip_push: "true"
+          verify: "true"
+          verify_min_age: "true"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,21 +3,22 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   tagpr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       tag: ${{ steps.tagpr.outputs.tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.24'
 
@@ -26,24 +27,26 @@ jobs:
 
       - name: Run tagpr
         id: tagpr
-        uses: Songmu/tagpr@v1
+        uses: Songmu/tagpr@d1b8138b7a31075141b6cd64103de9485ced7ac9 # v1.20.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: tagpr
     if: needs.tagpr.outputs.tag != ''
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ needs.tagpr.outputs.tag }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.24'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           args: release --clean

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/v4.1.0/json-schema/pinact.json
+version: 3
+min_age:
+  value: 7


### PR DESCRIPTION
## 概要

GitHub Actions のサプライチェーンリスクを下げるため、workflow 内の Action 参照をタグ指定からフル長の commit SHA 指定へ固定しました。

## 変更内容

- 既存の `uses:` を pinact で commit SHA に固定
- 元のバージョンをコメントとして保持し、後続の更新・検証で追えるように変更
- pinact の検証用 workflow を追加
- `.pinact.yaml` で最小リリース年齢を 7 日に設定
- workflow の `GITHUB_TOKEN` 権限を必要な job に寄せて最小化

## 確認したこと

- `/tmp/pinact-v4.1.0/pinact run -fix=false -no-api`
- `/tmp/pinact-v4.1.0/pinact run -fix=false -verify-comment -verify-min-age`
- `git diff --check HEAD`
- `go test ./...`

## 補足

ローカル環境に `actionlint` が無かったため、GitHub Actions 専用の lint は未実行です。
