### PR TITLE
mainへのpushでもpinact検証を実行する

### DIFF
--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -1,6 +1,9 @@
 name: pinact
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## 変更概要

`main` への直接 push でも pinact の検証を実行し、PR を経由しない更新を検知できるようにします。

## 主な変更内容

- `.github/workflows/pinact.yaml` に `push` トリガーを追加
- 対象ブランチを `main` に限定
- 既存の pull request / 手動実行トリガーは維持

## 検証内容と結果

- `actionlint 1.7.12 .github/workflows/*.yaml`: 成功
- `pinact 4.1.0 --config .pinact.yaml run --fix=false --verify --verify-min-age`: 成功
- `go test ./...`（umask 022）: 成功
- `git diff --check`: 成功

## 既知の問題または未実施事項

- push 時の検証は変更投入後の検知であり、直接 push 自体を防止しません
- PR 必須化と必須チェック設定は別PRで対応します
