### PR TITLE
pinactを全PRで実行して必須チェック化に備える

### DIFF
--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -7,13 +7,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/**"
-      - ".pinact.yaml"
-      - "action.yml"
-      - "action.yaml"
-      - "**/action.yml"
-      - "**/action.yaml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 変更概要

pinact workflow を `main` 向けのすべての pull request で実行し、required status check として安全に設定できるようにします。

## 主な変更内容

- `pull_request.paths` フィルターを削除
- workflow や Action 定義を変更しないPRでも `pinact` checkを必ず生成
- `push`、`workflow_dispatch`、最小権限設定は維持

## 検証内容と結果

- `actionlint 1.7.12 .github/workflows/*.yaml`: 成功
- `pinact 4.1.0 --config .pinact.yaml run --fix=false --verify --verify-min-age`: 成功
- `go test ./...`（umask 022）: 成功
- `git diff --check`: 成功

## 既知の問題または未実施事項

- すべてのPRで軽量なpinact jobが1件追加実行されます
- GitHubのbranch ruleset有効化とrequired check設定は、このPRのマージ後にリポジトリ設定として実施します
