### PR TITLE
GitHub ActionsをDependabotで定期更新する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## 変更概要

SHAで固定したGitHub Actionsを定期的に更新するため、Dependabotのversion updatesを有効化します。

## 主な変更内容

- `.github/dependabot.yml` を追加
- `github-actions` ecosystemをリポジトリルートで監視
- 更新確認を週次で実行
- version updateのcooldownをpinactのmin-ageと同じ7日に設定

## 検証内容と結果

- Ruby YAML parserによる構文・必須値確認: 成功
- `actionlint 1.7.12 .github/workflows/*.yaml`: 成功
- `pinact 4.1.0 --config .pinact.yaml run --fix=false --verify --verify-min-age`: 成功
- `go test ./...`（umask 022）: 成功
- `git diff --check`: 成功

## 既知の問題または未実施事項

- 初回のDependabot実行と更新PR作成はマージ後にGitHub側で行われます
- Dependabotのsecurity updateにはcooldownが適用されないため、公開7日未満の緊急更新ではpinact側の例外を個別判断する必要があります
