### PR TITLE
任意階層のローカルActionをpinactの検査対象にする

### DIFF
--- a/.github/scripts/create-pinact-config.sh
+++ b/.github/scripts/create-pinact-config.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly output="${1:?output config path is required}"
+
+if [[ ! -f .pinact.yaml || ! -r .pinact.yaml ]]; then
+  echo ".pinact.yaml is required and must be readable" >&2
+  exit 1
+fi
+
+if [[ "${output}" == ".pinact.yaml" ]]; then
+  echo "refusing to overwrite .pinact.yaml" >&2
+  exit 1
+fi
+
+if [[ -e "${output}" || -L "${output}" ]]; then
+  echo "refusing to overwrite existing output: ${output}" >&2
+  exit 1
+fi
+
+command -v jq >/dev/null
+command -v iconv >/dev/null
+
+git ls-files -z -- \
+  ':(glob).github/workflows/*.yml' \
+  ':(glob).github/workflows/*.yaml' \
+  ':(glob)**/action.yml' \
+  ':(glob)**/action.yaml' |
+  while IFS= read -r -d '' file; do
+    if ! printf '%s' "${file}" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1; then
+      printf 'pinact target path is not valid UTF-8: %q\n' "${file}" >&2
+      exit 1
+    fi
+
+    pattern="${file//\\/\\\\}"
+    pattern="${pattern//\*/\\*}"
+    pattern="${pattern//\?/\\?}"
+    pattern="${pattern//\[/\\[}"
+    jq -Rn --arg path "${pattern}" '$path'
+  done |
+  jq -s '
+    if length == 0 then
+      error("no pinact target files found")
+    else
+      {
+        version: 3,
+        min_age: {},
+        files: map({pattern: .})
+      }
+    end
+  ' >"${output}"

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -21,10 +21,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Create pinact config
+        run: bash .github/scripts/create-pinact-config.sh .pinact.ci.yaml
+
       - name: Check pinned Actions
         uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        env:
+          PINACT_GLOBAL_CONFIG: .pinact.yaml
         with:
-          config: .pinact.yaml
+          config: .pinact.ci.yaml
           fix: "false"
           skip_push: "true"
           verify: "true"


### PR DESCRIPTION
## 変更概要

pinact の既定走査深度に依存せず、リポジトリ内の任意階層にあるローカル Action を検査対象にします。

## 主な変更内容

- tracked な workflow と `action.yml` / `action.yaml` を NUL 区切りで列挙し、pinact 用の一時設定を生成
- Go `filepath.Glob` のメタ文字をエスケープし、空白・改行・特殊文字を含むパスも exact path として安全に処理
- 非 UTF-8 パス、対象ゼロ、基礎設定欠落、既存出力・symlink、列挙途中の失敗を fail closed で処理
- `.pinact.yaml` を global config として使い、既存の `min_age: 7` と検証設定を維持

## 検証内容と結果

- `bash -n .github/scripts/create-pinact-config.sh`: 成功
- actionlint 1.7.12: 全 workflow で成功
- pinact v4.0.0（公式チェックサム照合済み）: SHA・タグコメント・min-age のオンライン検証に成功
- 一時 fixture: 4 階層超、ルート直下、空白・改行・タブ・`\\`・`*`・`?`・`[`・`]` を含むパスで検出を確認
- 一時 fixture: 未固定 Action、非 UTF-8 パス、対象ゼロ、`git ls-files` 途中失敗で非 0 終了を確認
- `go test ./...`（`umask 022`）: 成功
- `git diff --check`: 成功
- 独立した 2 系統の自己レビュー: 修正必須事項なし

## 既知の問題または未実施事項

- `ubuntu-latest` に同梱される `jq` と `iconv` を使用します。欠落時は検査漏れではなく CI エラーになります。
- 深い階層・特殊パスの fixture 検証は一時環境で実施しており、fixture 自体はリポジトリに追加していません。
- 生成途中に失敗した場合は不完全な一時設定が残り得ますが、その step が非 0 終了するため後続の pinact は実行されません。
