### PR TITLE
ローカルActionのDependabot更新範囲を検証する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
     schedule:
       interval: weekly
     cooldown:

--- a/.github/scripts/check-dependabot-action-coverage.rb
+++ b/.github/scripts/check-dependabot-action-coverage.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "open3"
+require "pathname"
+require "set"
+require "yaml"
+
+CONFIG_PATH = ".github/dependabot.yml"
+WORKFLOW_DIRECTORY = ".github/workflows"
+
+def fail_check(message)
+  warn message
+  exit 1
+end
+
+def normalize_directory(directory)
+  # Match Dependabot::Job::SourceDefinition's path normalization.
+  normalized = Pathname.new(directory).cleanpath.to_s
+  normalized = "/#{normalized}" unless normalized.start_with?("/")
+  relative = normalized.delete_prefix("/")
+  if relative.split("/").include?("..")
+    fail_check("Dependabot directory must stay within the repository: #{directory.inspect}")
+  end
+
+  normalized
+end
+
+def glob?(directory)
+  directory.include?("*") || directory.include?("?") ||
+    (directory.include?("[") && directory.include?("]"))
+end
+
+def covered_directories(entries)
+  entries.each_with_object(Set.new) do |(pattern, allow_glob), covered|
+    directory = normalize_directory(pattern)
+    if directory == "/"
+      covered << "."
+      covered << WORKFLOW_DIRECTORY
+      next
+    end
+
+    relative = directory.delete_prefix("/")
+    matches = allow_glob && glob?(directory) ? Dir.glob(relative, File::FNM_DOTMATCH) : [relative]
+    matches.select { |path| File.directory?(path) }.each do |path|
+      canonical = Pathname.new(path).cleanpath.to_s
+      covered << canonical
+      # Dependabot's file fetcher also cleans "/." to "/" and then scans workflows.
+      covered << WORKFLOW_DIRECTORY if canonical == "."
+    end
+  end
+end
+
+def dependabot_directory_entries
+  config = YAML.safe_load_file(CONFIG_PATH, aliases: false)
+  updates = config.is_a?(Hash) ? config["updates"] : nil
+  fail_check("#{CONFIG_PATH} must contain an updates list") unless updates.is_a?(Array)
+
+  definitions = updates.select do |update|
+    update.is_a?(Hash) && update["package-ecosystem"] == "github-actions" &&
+      [nil, "main"].include?(update["target-branch"])
+  end
+  fail_check("#{CONFIG_PATH} must configure github-actions updates for main") if definitions.empty?
+
+  definitions.flat_map do |definition|
+    if definition.key?("exclude-paths") && definition["exclude-paths"] != []
+      fail_check("github-actions updates must not exclude manifest paths")
+    end
+
+    has_directory = definition.key?("directory")
+    has_directories = definition.key?("directories")
+    unless has_directory ^ has_directories
+      fail_check("github-actions updates must define exactly one of directory or directories")
+    end
+
+    directories = has_directories ? definition["directories"] : [definition["directory"]]
+    unless directories.is_a?(Array) && !directories.empty? &&
+           directories.all? { |directory| directory.is_a?(String) && !directory.empty? }
+      fail_check("github-actions directory entries must be non-empty strings")
+    end
+    directories.map { |directory| [directory, has_directories] }
+  end
+rescue Psych::Exception, SystemCallError => e
+  fail_check("failed to read #{CONFIG_PATH}: #{e.message}")
+end
+
+stdout, stderr, status = Open3.capture3(
+  "git", "ls-files", "-z", "--",
+  ":(glob).github/workflows/*.yml",
+  ":(glob).github/workflows/*.yaml",
+  ":(glob)**/action.yml",
+  ":(glob)**/action.yaml"
+)
+fail_check("git ls-files failed: #{stderr.strip}") unless status.success?
+
+required_directories = stdout.b.split("\0").each_with_object(Set.new) do |raw_path, required|
+  path = raw_path.force_encoding(Encoding::UTF_8)
+  fail_check("GitHub Actions path is not valid UTF-8: #{path.dump}") unless path.valid_encoding?
+
+  required << File.dirname(path)
+end
+fail_check("no GitHub Actions files were found") if required_directories.empty?
+
+missing = required_directories - covered_directories(dependabot_directory_entries)
+unless missing.empty?
+  fail_check(
+    "Dependabot does not cover GitHub Actions in: #{missing.to_a.sort.map(&:dump).join(', ')}. " \
+    "Add the directories to the github-actions update configuration."
+  )
+end

--- a/.github/workflows/pinact.yaml
+++ b/.github/workflows/pinact.yaml
@@ -21,6 +21,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check Dependabot coverage
+        run: ruby .github/scripts/check-dependabot-action-coverage.rb
+
       - name: Create pinact config
         run: bash .github/scripts/create-pinact-config.sh .pinact.ci.yaml
 


### PR DESCRIPTION
## 変更概要

pinact は任意階層のローカル `action.yml` / `action.yaml` を検査しますが、Dependabot の `github-actions` 設定が `directory: /` のままだと、リポジトリ直下と `.github/workflows` 以外のローカル Action は更新対象になりませんでした。

GitHub Actions の全 manifest が Dependabot のディレクトリ選択に含まれることを、必須の `pinact` チェック内で検証します。

## 主な変更内容

- `.github/dependabot.yml` を将来複数ディレクトリへ拡張できる `directories` 形式へ変更
- Git 管理中の workflow と任意階層の `action.yml` / `action.yaml` を列挙し、Dependabot の対象ディレクトリと照合するスクリプトを追加
- Dependabot Core と同じ `Pathname.cleanpath`、複数形でのみ有効な glob、`File::FNM_DOTMATCH`、ルートディレクトリの特殊処理を再現
- `directory` / `directories` の不正な併用、空設定、範囲外パス、非 UTF-8 パス、manifest を除外する `exclude-paths` を fail closed で拒否
- 上記検証を、main の strict required check である `pinact` ジョブへ追加

## 検証内容と結果

- `ruby -c` / `ruby -w` / 現在のリポジトリに対する coverage checker: 成功
- `/tmp` の独立リポジトリで35ケース: 全成功
  - root、workflow、深い階層、exact / globstar / hidden directory
  - singular / plural、`.`、重複 slash、`..` の正規化
  - 空白、改行、タブ、Unicode、glob特殊文字、backslash、非 UTF-8
  - 不正YAML、空配列、キー排他違反、対象なし、Git失敗、`exclude-paths`
- actionlint v1.7.12: 成功
- `bash -n .github/scripts/create-pinact-config.sh`: 成功
- pinact v4.0.0（workflow と同版）
  - `--no-api --fix=false`: 成功
  - GitHub APIを用いた `--verify --verify-min-age`: 成功
- 全YAMLの構文解析: 成功
- `go test ./...`: 成功
- `git diff --check`: 成功
- 2件の独立コードレビュー: 承認相当、未解決の P1 / P2 なし

## 既知の問題または未実施事項

- 35ケースの fixture は一時リポジトリで実行しており、リポジトリ内の恒久テストにはしていません。通常経路は全PRの `pinact` ジョブで毎回実行されます。
- このスクリプトは GitHub Actions manifest のディレクトリ／除外カバレッジを検証するもので、Dependabot 設定全体の schema validator ではありません。schema 検証は GitHub の Dependabot config validation に委ねます。
- `allow`、`ignore`、`open-pull-requests-limit` は更新方針の設定であり、このカバレッジ検証の対象外です。現行設定では使用していません。
- `target-branch` 省略時にデフォルトブランチを使う Dependabot の仕様に依存します。現在のデフォルトブランチは `main` です。
